### PR TITLE
Added PyPy3 to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
+  - "pypy3"
 
 install:
   - pip install -r requirements-dev.txt


### PR DESCRIPTION
Forgot to mention that I also enabled [Travis-CI](https://travis-ci.org) and [Coveralls](https://coveralls.io) via the `.travis.yml` file but you have to turn them on in your repo.

If you're not familiar Travis is a continuous integration service that is free for public repos and is a really easy way to run the test suite in a clean environment against multiple versions of Python and Coveralls keeps track of the code coverage report generated by `nosetests --with-coverage`.  Both also have badges that can be added to the readme.  They both generate reports automatically for pull requests, which is really useful.

This pull request adds `PyPy3` to the Travis configfile, which I neglected to include originally.  You can see what the Travis and Coveralls report looks like for my branch before turning it on.

https://travis-ci.org/geowurster/emoji
https://coveralls.io/r/geowurster/emoji

Image blocks to add for the badges:

```rst
.. image:: https://travis-ci.org/carpedm20/emoji.svg?branch=master
    :target: https://travis-ci.org/carpedm20/emoji

.. image:: https://coveralls.io/repos/carpedm20/emoji/badge.svg?branch=master
    :target: https://coveralls.io/r/carpedm20/emoji
```