### PR TITLE
Use codecs.open() instead of open() when processing readme in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ Setup script for emoji
 """
 
 
+from codecs import open
 import os
 try:
     from setuptools import setup
@@ -14,7 +15,7 @@ except ImportError:
     from distutils.core import setup
 
 
-with open('README.rst') as f:
+with open('README.rst', encoding='UTF-8') as f:
     readme_content = f.read().strip()
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ Setup script for emoji
 
 from codecs import open
 import os
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 
 with open('README.rst', encoding='UTF-8') as f:
@@ -27,7 +24,7 @@ version = None
 author = None
 email = None
 source = None
-with open(os.path.join('emoji', '__init__.py')) as f:
+with open(os.path.join('emoji', '__init__.py'), encoding='utf-8') as f:
     for line in f:
         if line.strip().startswith('__version__'):
             version = line.split('=')[1].strip().replace('"', '').replace("'", '')


### PR DESCRIPTION
Closes #2
Closes #5

Installs were choking on the non-ascii characters in the readme.