### PR TITLE
Fix BeautifulSoup warning

### DIFF
--- a/utils/get-codes-from-unicode-consortium.py
+++ b/utils/get-codes-from-unicode-consortium.py
@@ -23,7 +23,7 @@ url = 'http://www.unicode.org/Public/emoji/1.0/full-emoji-list.html'
 
 response = requests.get(url)
 response.raise_for_status()
-soup = BeautifulSoup(response.text)
+soup = BeautifulSoup(response.text, "html.parser")
 
 # with open('utils/content.html') as f:
 #     soup = BeautifulSoup(f.read())


### PR DESCRIPTION
Without this change, BeautifulSoup4 gives this warning when running the `utils/get-codes-from-unicode-consortium.py` script:

```
$ python ./utils/get-codes-from-unicode-consortium.py
/Users/adam/code/emoji/venv/lib/python3.4/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")

  markup_type=markup_type))
```