### PR TITLE
add demojize to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,12 @@ both the full list and aliases.
 .. code-block:: python
 
     >> import emoji
-    >> print(emoji.emojize('Python is :thumbs_up_sign:'))
+    >> print(emoji.emojize('Python is :thumbs_up:'))
     Python is 👍
     >> print(emoji.emojize('Python is :thumbsup:', use_aliases=True))
     Python is 👍
+    >> print(emoji.demojize('Python is 👍'))
+    Python is :thumbs_up:
 
 
 Installation


### PR DESCRIPTION
Adding this so it's not necessary to look into the code to see how to do this. :)

There also seems to have been an error in the previous documentation. `emoji.emojize('Python is :thumbs_up_sign:')` doesn't seem to work, the "standard" emoji code seems to be `:thumbs_up:`. That's also what `demojize` returns.