### PR TITLE
at runtime expect to see NO ICON - clarify

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -2,5 +2,5 @@
 import emoji
 
 print(emoji.emojize('Water! :water_wave:'))
-print(emoji.demojize(u' at runtime expect to see a picture or icon but a regulate text instead     🌊')) # for Python 2.x
-# print(emoji.demojize('🌊')) # for Python 3.x
+print(emoji.demojize(u' at runtime expect NOT to see a picture here, but regular text instead -->    🌊')) # for Python 2.x
+# print(emoji.demojize('🌊')) # for Python 3.x   ##  also NO pic to be seen here. it is  "emo" and "demo" function i.e. un-emoize.

--- a/example/example.py
+++ b/example/example.py
@@ -2,5 +2,5 @@
 import emoji
 
 print(emoji.emojize('Water! :water_wave:'))
-print(emoji.demojize(u'🌊')) # for Python 2.x
+print(emoji.demojize(u' at runtime expect to see a picture or icon but a regulate text instead     🌊')) # for Python 2.x
 # print(emoji.demojize('🌊')) # for Python 3.x


### PR DESCRIPTION
at runtime expect to see NO ICON - clarify - at runtime expect to see TEXT instead. 

Without this hint, the example is pretty much worthless for demonstration purposes.