### PR TITLE
Bug Fixed - emoji_lis and emoji_count

### DIFF
--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -18,6 +18,8 @@ emoji terminal output for Python.
 from emoji.core import emojize
 from emoji.core import demojize
 from emoji.core import get_emoji_regexp
+from emoji.core import emoji_count
+from emoji.core import emoji_lis
 from emoji.unicode_codes import EMOJI_ALIAS_UNICODE
 from emoji.unicode_codes import EMOJI_UNICODE
 from emoji.unicode_codes import UNICODE_EMOJI

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -98,7 +98,7 @@ def emoji_lis(string):
     """
     _entities = []
     for pos,c in enumerate(string):
-        if c in emoji.UNICODE_EMOJI:
+        if c in unicode_codes.UNICODE_EMOJI:
             _entities.append({
                 "location":pos,
                 "emoji": c
@@ -109,7 +109,7 @@ def emoji_count(string):
    """Returns the count of emojis in a string"""
    c=0
    for i in string:
-     if i in emoji.UNICODE_EMOJI:
+     if i in unicode_codes.UNICODE_EMOJI:
 	      c=c+1
    return(c)
    


### PR DESCRIPTION
Fix origin methods emoji_lis and emoji_count.
The original function imported the wrong module name and would raise the below Error.

`` ImportError: No module named 'emoji'``.

This pull request modify the import module in core.py and add the new methods in __init__.py.