### PR TITLE
Add `:robot:` as alias for `:robot_face:` emoji

### DIFF
--- a/emoji/unicode_codes.py
+++ b/emoji/unicode_codes.py
@@ -3840,6 +3840,7 @@ EMOJI_ALIAS_UNICODE = dict(EMOJI_UNICODE.items(), **{
     u':ring:': u'\U0001F48D',
     u':sweet_potato:': u'\U0001F360',
     u':robot_face:': u'\U0001F916',
+    u':robot:': u'\U0001F916',
     u':rocket:': u'\U0001F680',
     u':rolled__up_newspaper:': u'\U0001F5DE',
     u':roller_coaster:': u'\U0001F3A2',


### PR DESCRIPTION
GitHub only understands `:robot:`, and does not have `:robot_face:` in its emoji list.

I've attempted to put the alias in an appropriate spot in the list of aliases—though I admit, I could not figure out exactly how the list is sorted. Apologies if it's in the wrong spot.