### PR TITLE
#107 - Fix: :egg: error aliace or should it be

### DIFF
--- a/emoji/unicode_codes.py
+++ b/emoji/unicode_codes.py
@@ -3051,6 +3051,7 @@ EMOJI_ALIAS_UNICODE = dict(EMOJI_UNICODE.items(), **{
     u':rice:': u'\U0001F35A',
     u':cookie:': u'\U0001F36A',
     u':egg:': u'\U0001F373',
+    u':egg2:': u'\U0001F95A',
     u':copyright:': u'\U000000A9',
     u':couch_and_lamp:': u'\U0001F6CB',
     u':couple_with_heart:': u'\U0001F491',


### PR DESCRIPTION
Good evening. When using the flag `use_aliases=True`, `:egg:` displays scrambled eggs in the pan, it seems this is not unexpected behavior, but that would not break the dependencies added egg like `:egg2:`