### PR TITLE
Fix SyntaxWarning using a literal with 'is' in Python 3.8

### DIFF
--- a/utils/get-codes-from-unicode-consortium.py
+++ b/utils/get-codes-from-unicode-consortium.py
@@ -40,7 +40,7 @@ for row in soup.find('table').find_all('tr'):
     if d:
         _code = []
         for c in d['Code'].split(' '):
-            if len(c) is 6:
+            if len(c) == 6:
                 _code.append(c.replace('+', '0000'))
             else:
                 _code.append(c.replace('+', '000'))


### PR DESCRIPTION
Warning message:

```
./utils/get-codes-from-unicode-consortium.py:43: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(c) is 6:
```

Fixes #115