### PR TITLE
Handle multi-character emojis in emoji_lis, emoji_count

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -99,20 +99,26 @@ def get_emoji_regexp():
         _EMOJI_REGEXP = re.compile(pattern)
     return _EMOJI_REGEXP
 
+
 def emoji_lis(string):
-    """Return the location and emoji in list of dic format
-    >>>emoji.emoji_lis("Hi, I am fine. 😁")
-    >>>[{'location': 15, 'emoji': '😁'}]
+    """
+    Returns the location and emoji in list of dict format
+    >>> emoji.emoji_lis("Hi, I am fine. 😁")
+    >>> [{'location': 15, 'emoji': '😁'}]
     """
     _entities = []
-    for pos,c in enumerate(string):
-        if c in unicode_codes.UNICODE_EMOJI:
+
+    for match in get_emoji_regexp().finditer(string):
             _entities.append({
-                "location":pos,
-                "emoji": c
-                })
+                "location": match.start(),
+                "emoji": match.group()
+            })
+
     return _entities
 
+
 def emoji_count(string):
-   """Returns the count of emojis in a string"""
-   return sum(1 for i in string if i in unicode_codes.UNICODE_EMOJI)
+    """
+    Returns the count of emojis in a string
+    """
+    return len(emoji_lis(string))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,10 +66,14 @@ def test_demojize_complicated_string():
     destructed = emoji.demojize(emojid)
     assert constructed == destructed, "%s != %s" % (constructed, destructed)
 
+
 def test_emoji_lis():
-    assert emoji.emoji_lis("Hi, I am fine. 😁") == [{'location': 15, 'emoji': '😁'}] 
+    assert emoji.emoji_lis("Hi, I am fine. 😁") == [{'location': 15, 'emoji': '😁'}]
     assert emoji.emoji_lis("Hi") == []
+    assert emoji.emoji_lis("Hello 🇫🇷👌") == [{'emoji': '🇫🇷', 'location': 6}, {'emoji': '👌', 'location': 8}]
+
 
 def test_emoji_count():
-    assert emoji.emoji_count("Hi, I am fine. 😁") == 1 
+    assert emoji.emoji_count("Hi, I am fine. 😁") == 1
     assert emoji.emoji_count("Hi") == 0
+    assert emoji.emoji_count("Hello 🇫🇷👌") == 2


### PR DESCRIPTION
Fixes #117 #77

emoji_lis, emoji_count were not prioritizing multi-character emojis. Therefore, a string like `Hello 🇫🇷`was counted as 2 emojis instead of one.

My PR uses the regexp to fix this issue. I have added tests