### PR TITLE
Add replace_emoji to top-level module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Developing
     $ git clone https://github.com/carpedm20/emoji.git
     $ cd emoji
     $ pip install -e .\[dev\]
-    $ nosetests
+    $ pytest
 
 The ``utils/get-codes-from-unicode-consortium.py`` may help when updating
 ``unicode_codes.py`` but is not guaranteed to work.  Generally speaking it

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -20,7 +20,7 @@ from emoji.unicode_codes import *
 
 __all__ = [
     # emoji.core
-    'emojize', 'demojize', 'get_emoji_regexp', 'emoji_count', 'emoji_lis',
+    'emojize', 'demojize', 'get_emoji_regexp', 'emoji_count', 'emoji_lis', 'replace_emoji',
     # emoji.unicode_codes
     'EMOJI_UNICODE_ENGLISH', 'EMOJI_UNICODE_SPANISH', 'EMOJI_UNICODE_PORTUGUESE', 'EMOJI_UNICODE_ITALIAN',
     'UNICODE_EMOJI_ENGLISH', 'UNICODE_EMOJI_SPANISH', 'UNICODE_EMOJI_PORTUGUESE', 'UNICODE_EMOJI_ITALIAN',

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -18,6 +18,7 @@ from emoji import unicode_codes
 __all__ = [
     'emojize', 'demojize', 'get_emoji_regexp',
     'emoji_lis', 'distinct_emoji_lis', 'emoji_count',
+    'replace_emoji',
 ]
 
 
@@ -102,7 +103,7 @@ def demojize(
     return re.sub(u'\ufe0f', '', (get_emoji_regexp(language).sub(replace, string)))
 
 
-def replace_emoji(string, language='en', replace=''):
+def replace_emoji(string, replace='', language='en', ):
     """Replace unicode emoji in a customizable string.
     """
     return re.sub(u'\ufe0f', '', (get_emoji_regexp(language).sub(replace, string)))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -83,3 +83,10 @@ def test_emoji_count():
     assert emoji.emoji_count('Hi, I am fine. 😁') == 1
     assert emoji.emoji_count('Hi') == 0
     assert emoji.emoji_count('Hello 🇫🇷👌') == 2
+
+
+def test_replace_emoji():
+    assert emoji.replace_emoji('Hi, I am fine. 😁') == 'Hi, I am fine. '
+    assert emoji.replace_emoji('Hi') == 'Hi'
+    assert emoji.replace_emoji('Hello 🇫🇷👌') == 'Hello '
+    assert emoji.replace_emoji('Hello 🇫🇷👌', 'x') == 'Hello xx'


### PR DESCRIPTION
This adds `replace_emoji` to the top-level module, so users can use it by just importing emoji. For example

```py
import emoji
emoji.replace_emoji("original string", "x")
```

I also made the following tweaks:
- Changed the param order, such that the replacement char is the 2nd argument of `replace_emoji`. This seems like something users would override more often than `language` (but maybe this is because I'm a native english speaker and I like the default language choice :wink: )
- Added tests
- Changed instructions for running unit tests to use `pytest` instead of `nosetests`