### PR TITLE
Add overview of all emoji on Github Pages

### DIFF
--- a/.github/workflows/updateGithubPages.yml
+++ b/.github/workflows/updateGithubPages.yml
@@ -3,7 +3,7 @@ name: updateGithubPages
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   generateGHPages:

--- a/.github/workflows/updateGithubPages.yml
+++ b/.github/workflows/updateGithubPages.yml
@@ -1,0 +1,52 @@
+name: updateGithubPages
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  generateGHPages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python setup.py install
+    - name: Retain directory utils/gh-pages
+      run: |
+        cp -R utils/gh-pages ..
+    - name: Switch to branch gh-pages
+      run: |
+        git stash
+        git config --global user.name github-actions
+        git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git fetch origin
+        if ! git checkout -b gh-pages origin/gh-pages; then
+            echo Create new orphan branch gh-pages;
+            git checkout --orphan gh-pages;
+            git rm -rf .;
+        fi;
+    - name: Install requirements
+      run: |
+        python -m pip install -r ../gh-pages/requirements.txt
+    - name: Generate HTML
+      run: |
+        python ../gh-pages/generatePages.py -minify
+    - name: Move files into repository
+      run: |
+        mv ../gh-pages/index.html .
+        mv ../gh-pages/all.html .
+        mv ../gh-pages/main.css .
+        mv ../gh-pages/main.js .
+    - name: git commit & push
+      run: |
+        git add index.html all.html main.css main.js
+        # Use "|| true" or "--allow-empty"  otherwise the action fails for empty commits
+        git commit -m "Updated gh-pages" || true
+        git push -u origin gh-pages

--- a/utils/gh-pages/.gitignore
+++ b/utils/gh-pages/.gitignore
@@ -1,0 +1,2 @@
+index.html
+all.html

--- a/utils/gh-pages/README.rst
+++ b/utils/gh-pages/README.rst
@@ -1,0 +1,23 @@
+Emoji overview on github pages
+==============================
+
+Generate a HTML website that contains all emoji and names that are currently supported.
+
+Github pages
+-------------
+
+https://carpedm20.github.io/emoji/
+
+On every release the content on the github pages is updated by a github action:
+`updateGithubPages.yml <../../.github/workflows/updateGithubPages.yml>`__.
+
+You can view the generated source in the `gh-pages <https://github.com/carpedm20/emoji/tree/gh-pages>`__ branch.
+
+
+Build pages locally
+-------------------
+
+.. code-block:: sh
+
+    pip install -r utils/gh-pages/requirements.txt
+    python utils/gh-pages/generatePages.py

--- a/utils/gh-pages/generatePages.py
+++ b/utils/gh-pages/generatePages.py
@@ -1,0 +1,114 @@
+"""Generate the files index.html and all.html that will contain a table of all supported emoji
+Run with -minify to minify HTML for production"""
+
+import sys
+import os
+import codecs
+import django.conf
+import django.template
+from htmlmin.minify import html_minify
+
+try:
+    import emoji
+except ImportError:
+    include = os.path.relpath(os.path.join(os.path.dirname(__file__), "../.."))
+    sys.path.insert(0, include)
+    import emoji
+    print("Imported emoji from %s" %
+          os.path.abspath(os.path.join(include, "flag")))
+
+# Configuration
+OUT_DIR = os.path.abspath(os.path.dirname(__file__))
+TEMPLATE_DIR = os.path.abspath(os.path.dirname(__file__))
+TEMPLATE_FILE = os.path.join(TEMPLATE_DIR, "template.html")
+data = {"defaultListName": 'UNICODE_EMOJI_ENGLISH'}
+
+languages = {
+    "UNICODE_EMOJI_ENGLISH": emoji.emojize(":United_Kingdom:"),
+    "UNICODE_EMOJI_ALIAS_ENGLISH": emoji.emojize(":United_Kingdom:alias"),
+    "UNICODE_EMOJI_SPANISH": emoji.emojize(":Spain:"),
+    "UNICODE_EMOJI_PORTUGUESE": emoji.emojize(":Portugal:"),
+    "UNICODE_EMOJI_ITALIAN": emoji.emojize(":Italy:")
+}
+language_args = {
+    "UNICODE_EMOJI_ALIAS_ENGLISH": 'language="en", use_aliases=True'
+}
+
+
+minify_enabled = sys.argv[-1] == '-minify'
+if not minify_enabled:
+    print("Run with -minify to minify HTML")
+
+
+print("Collecting emoji data...")
+for code, unicode_emojis in emoji.UNICODE_EMOJI.items():
+    for var_name in emoji.__all__:
+        if var_name == data["defaultListName"]:
+            language_args[var_name] = ""
+        elif unicode_emojis == getattr(emoji, var_name):
+            language_args[var_name] = f'language="{code}"'
+            break
+
+data["lists"] = lists = []
+for var_name in emoji.__all__:
+    if not var_name.startswith("UNICODE_EMOJI_"):
+        continue
+
+    var_name_pretty = languages[var_name] if var_name in languages else var_name
+    language_arg = language_args[var_name] if var_name in language_args else "[TODO]"
+
+    emoji_list = []
+    for code, name in getattr(emoji, var_name).items():
+        emoji_list.append({
+            "code": code,
+            "name": name,
+            "unicode": code.encode('ascii', 'backslashreplace').decode('ascii'),
+            "charname": code.encode('ascii', 'namereplace').decode('ascii'),
+            "xml": code.encode('ascii', 'xmlcharrefreplace').decode('ascii')
+        })
+
+    listentry = {
+        "name": var_name,
+        "pretty": var_name_pretty,
+        "languageArg": language_arg,
+        "emojis": emoji_list
+    }
+    lists.append(listentry)
+
+
+# Render with django
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [TEMPLATE_DIR],
+    }
+]
+
+django.conf.settings.configure(TEMPLATES=TEMPLATES)
+django.setup()
+template = django.template.loader.get_template(TEMPLATE_FILE)
+
+print("Render 'all.html' ...")
+with codecs.open(os.path.join(OUT_DIR, "all.html"), "w", encoding="utf-8") as f:
+    html = template.render(data)
+    if minify_enabled:
+        print("Minify 'all.html' ...")
+        html = html_minify(html)
+    f.write(html)
+    print(f"Wrote to {os.path.join(OUT_DIR, 'all.html')}")
+
+print("Render 'index.html' ...")
+# Remove emoji except for default list
+for listentry in lists:
+    if listentry["name"] != data["defaultListName"]:
+        listentry["emojis"] = []
+
+with codecs.open(os.path.join(OUT_DIR, "index.html"), "w", encoding="utf-8") as f:
+    html = template.render(data)
+    if minify_enabled:
+        print("Minify 'index.html' ...")
+        html = html_minify(html)
+    f.write(html)
+    print(f"Wrote to {os.path.join(OUT_DIR, 'index.html')}")
+
+print("Done.")

--- a/utils/gh-pages/main.css
+++ b/utils/gh-pages/main.css
@@ -1,0 +1,313 @@
+:root {
+  --main-color: #111;
+  --main-bg: #f0f0ff;
+  --model-bg: #99f;
+  --modal-emoji-bg: white;
+  --table-font-family: monospace;
+  --table-header-bg: #ccf;
+  --table-listheader-bg: #ddf;
+  --table-even-bg: #ddf;
+  --table-odd-bg: #f0f0ff;
+  --font-family: "Segoe UI", "Nimbus Sans L", "Liberation Sans", "Open Sans", FreeSans, Arial, sans-serif;
+}
+
+body {
+  font-size: larger;
+  font-family: var(--font-family);
+  background-color: var(--main-bg);
+  color: var(--main-color);
+  position:relative;
+  min-height: 90vh;
+}
+
+h1 {
+  text-align: center;
+  font-size: x-large;
+}
+
+.footer {
+  position: absolute;
+  bottom: -3em;
+  padding: 1em;
+}
+
+.controls {
+  text-align: center;
+}
+
+.search {
+  display: inline-block;
+  box-sizing: border-box;
+  border-radius: 4px;
+  height: 2.1em;
+  background-color: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.06);
+  padding-left: .5em;
+  padding-right: .5em;
+}
+
+#search_full {
+  appearance: none;
+  font-size: 1em;
+  background: none;
+  outline: none;
+  border: none;
+  padding: 0;
+  height: 2.1em;
+  width: 17em;
+}
+
+.search_icon {
+  border-radius: 0 4px 4px 0;
+  color: #999;
+  font-size: 1.25em;
+  padding: 0 0.5em 0 0;
+  margin-top: -1px;
+  margin-bottom: -1px;
+  margin-right: -3px;
+  line-height: 1.5;
+  cursor: default;
+}
+
+.copiable {
+  user-select: all;
+  cursor: copy;
+}
+
+.copiable.copied::after {
+  display: block;
+  height: 28px;
+  opacity: 1.0;
+  background-color: #EEE;
+  color: black;
+  border-radius: 10px;
+  padding: 3px;
+  margin: 0px;
+  line-height: normal;
+  font-size: 15px;
+  font-weight: normal;
+  font-family: var(--font-family);
+  content: "Copied!";
+  position: absolute;
+  box-shadow: 0px 0px 10px #999 inset;
+  transition: opacity 2s
+}
+
+.copiable.copiedfadeout::after {
+  opacity: 0.0 !important;
+}
+
+.spinnerholder {
+  display: inline-block;
+  text-align: center;
+  margin: auto;
+  line-height: 2em;
+  vertical-align: middle;
+  width: 2em;
+}
+
+.roundspinner {
+  position: relative;
+  height: 30px;
+  width: 30px;
+  margin: 0px auto;
+  display: inline-block;
+  animation: spinnerrotation 3s infinite linear;
+  cursor: wait;
+  border: 3px solid #3e899fab;
+  border-bottom-color: transparent;
+  border-radius: 50%
+}
+
+@keyframes spinnerrotation {
+  from {
+    transform: rotate(0deg)
+  }
+
+  to {
+    transform: rotate(359deg)
+  }
+}
+
+.modal {
+  box-sizing: content-box;
+  background-color: transparent;
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+  max-height: 300px;
+  min-width: 280px;
+  max-width: 300px;
+}
+
+@media (min-width: 600px) and (min-height: 480px) {
+  .modal {
+    max-height: 460px;
+    max-width: 400px;
+  }
+}
+
+@media (min-width: 600px) and (min-height: 680px) {
+  .modal {
+    max-height: 660px;
+    max-width: 400px;
+  }
+}
+
+@media (min-width: 800px) and (min-height: 780px) {
+  .modal {
+    max-height: 760px;
+    max-width: 500px;
+  }
+}
+
+@media (min-width: 900px) and (min-height: 780px) {
+  .modal {
+    max-height: 760px;
+    max-width: 700px;
+  }
+}
+
+.modal .content {
+  background-color: var(--model-bg);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 15px;
+  max-width: 783px;
+  height: 100%;
+  max-height: 90vh;
+  width: 100%;
+  box-shadow: 5px 5px 10px black;
+}
+
+.modal samp {
+  display: block;
+  background-color: #fffd;
+  padding: 2px;
+  border-radius: 4px;
+}
+
+.modal samp.emoji {
+  display: block;
+  font-size: 100px;
+  background-color: var(--modal-emoji-bg);
+  text-align: center;
+  line-height: 1.2;
+  border: 2px solid #333;
+  box-shadow: 0px 0px 5px #999 inset;
+  padding: 25px 10px 10px 10px;
+  margin: 0px auto;
+}
+
+@media (min-width: 600px) and (min-height: 480px) {
+  .modal samp.emoji {
+    font-size: 126px;
+    line-height: 180px;
+    border: 4px solid #333;
+    box-shadow: 0px 0px 10px #999 inset;
+  }
+}
+
+.modal code {
+  display: block;
+  background-color: #fffd;
+  padding: 2px;
+  border-radius: 4px;
+  margin: 4px 0px;
+}
+
+.modal .name {
+  text-align: center;
+  font-size: larger;
+  font-weight: bolder;
+  margin-top: 0.3em;
+}
+
+table {
+  margin: auto;
+}
+
+td {
+  font-family: monospace;
+  word-wrap: anywhere;
+}
+
+td:first-child {
+  text-align: center
+}
+
+tr:nth-child(2n+1) {
+  background-color: var(--table-odd-bg)
+}
+
+tr:nth-child(2n) {
+  background-color: var(--table-even-bg)
+}
+
+tr.empty {
+  display: none
+}
+
+tr>th:nth-child(3),
+tr>td:nth-child(3),
+tr>th:nth-child(4),
+tr>td:nth-child(4),
+tr>th:nth-child(5),
+tr>td:nth-child(5) {
+  display: none
+}
+
+.allcolumns tr>th:nth-child(3),
+.allcolumns tr>td:nth-child(3),
+.allcolumns tr>th:nth-child(4),
+.allcolumns tr>td:nth-child(4),
+.allcolumns tr>th:nth-child(5),
+.allcolumns tr>td:nth-child(5) {
+  display: table-cell
+}
+
+tr.listheader>* {
+  background-color: var(--table-listheader-bg);
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+}
+
+tr.header>* {
+  background-color: var(--table-header-bg);
+  position: -webkit-sticky;
+  position: sticky;
+  top: 28px;
+}
+
+tr.listheader.UNICODE_EMOJI_ENGLISH>th:first-child {
+  background-color: #012169;
+  background-image: radial-gradient(white 15%, #012169 60%);
+  color: #c8102e
+}
+
+tr.listheader.UNICODE_EMOJI_ALIAS_ENGLISH>th:first-child {
+  background-image: radial-gradient(#c8102e80 5%, #ffffff80 15%, #01216980 60%);
+  color: black
+}
+
+tr.listheader.UNICODE_EMOJI_SPANISH>th:first-child {
+  background-color: #ffc400;
+  background-image: linear-gradient(#c60b1e, #ffc400, #ffc400, #c60b1e);
+  color: black
+}
+
+tr.listheader.UNICODE_EMOJI_PORTUGUESE>th:first-child {
+  background-color: red;
+  background-image: linear-gradient(to right, #060, red, red, red);
+  color: white
+}
+
+tr.listheader.UNICODE_EMOJI_ITALIAN>th:first-child {
+  background-color: #6cb06c;
+  background-image: linear-gradient(to right, #6cb06c, white, #f72a2a);
+  color: black
+}

--- a/utils/gh-pages/main.js
+++ b/utils/gh-pages/main.js
@@ -1,0 +1,318 @@
+'use strict'
+
+window.addEventListener('DOMContentLoaded', onLoad)
+
+function onLoad () {
+  // Show loading spinner immediately because the search cache will be building for some time
+  createSpinner()
+
+  // Add ui events
+  document.getElementById('search_full').addEventListener('keyup', searchFullHandler)
+
+  document.querySelectorAll('input[id^=enable_list_]').forEach(function (e) {
+    if (document.location.pathname.indexOf('all.html') === -1 && e.classList.contains('notloaded')) {
+      e.addEventListener('change', openAll)
+    } else {
+      e.addEventListener('change', searchFullHandler)
+    }
+  })
+
+  document.getElementById('enable_more_columns').addEventListener('change', toggleMoreColums)
+  document.querySelectorAll('#emoji_table tr').forEach(tr => tr.addEventListener('click', trClick))
+  document.addEventListener('selectionchange', onSelectionChange)
+  document.documentElement.addEventListener('click', closeModalOutsideClick)
+
+  // Fix table header height, otherwise the two table headers (position:sticky) may overlap
+  const rowHeight = document.querySelector('#emoji_table .listheader').clientHeight + 'px'
+  document.querySelectorAll('#emoji_table .header>*').forEach(e => (e.style.height = rowHeight))
+
+  // Parse url
+  if (document.location.search.indexOf('enableList=enable_list_') !== -1) {
+    const m = document.location.search.match(/enableList=(\w+)/)
+    if (m) {
+      document.getElementById(m[1]).checked = true
+    }
+  }
+  if (document.location.search.indexOf('query=') !== -1) {
+    const m = document.location.search.match(/query=([^=#&]+)/)
+    if (m) {
+      document.getElementById('search_full').value = decodeURIComponent(m[1])
+    }
+  }
+
+  // Update table (and build search cache)
+  toggleMoreColums()
+  searchFullHandler().then(hideSpinner)
+}
+
+function openAll () {
+  // Open all.html with parameters
+  this.checked = false
+  let params = `enableList=${this.id}`
+  if (document.getElementById('search_full').value) {
+    params += `&query=${encodeURIComponent(document.getElementById('search_full').value)}`
+  }
+  document.location.href = `all.html?${params}`
+}
+
+function onSelectionChange (e) {
+  // If the selected text is in a .copiable element, copy the whole textContent to the clipboard
+  const selection = document.getSelection()
+  if (selection.toString().length === 0) {
+    return
+  }
+  if (selection.anchorNode != null) {
+    let node = null
+    if ('classList' in selection.anchorNode && selection.anchorNode.classList.contains('copiable')) {
+      node = selection.anchorNode
+    } else if (selection.anchorNode.parentNode && 'classList' in selection.anchorNode.parentNode && selection.anchorNode.parentNode.classList.contains('copiable')) {
+      node = selection.anchorNode.parentNode
+    }
+    if (node) {
+      selection.removeAllRanges()
+      const range = document.createRange()
+      range.selectNode(node)
+      selection.addRange(range)
+      navigator.clipboard.writeText(node.textContent)
+      node.classList.add('copied')
+      window.setTimeout(() => node.classList.add('copiedfadeout'), 100)
+      window.setTimeout(() => { node.classList.remove('copied'); node.classList.remove('copiedfadeout') }, 2000)
+    }
+  }
+}
+
+function closeModalOutsideClick (ev) {
+  if (document.querySelector('.modal').style.display === 'none') {
+    return
+  }
+  let node = ev.target
+  while (node && node !== document.body) {
+    if ('classList' in node && node.classList.contains('modal')) {
+      return
+    }
+    node = node.parentNode
+  }
+  closeModal()
+}
+
+function closeModal () {
+  document.querySelector('.modal').style.display = 'none'
+}
+
+function examplePythonCode (fName, stringArg, argN) {
+  const s = `emoji.<span style="color:#6f42c1">${fName}</span>(<span style="color:#032f62">${JSON.stringify(stringArg)}</span>`
+  if (argN) {
+    return `${s}, ${argN.replace(/=(\w*)/g, '<span style="color:#005cc5">=$1</span>').replace(/("\w+")/g, '<span style="color:#032f62">$1</span>')})`
+  }
+  return `${s})`
+}
+
+function trClick () {
+  const tr = this
+  if (tr.className.indexOf('listheader') !== -1) {
+    // list header click
+
+  } else if (tr.className.indexOf('header') !== -1) {
+    // top header click
+
+  } else {
+    // emoji row click
+    const selection = document.getSelection()
+    if (selection && !selection.isCollapsed) {
+      // User is selecting text in the row -> don't open the modal
+      return
+    }
+    loadMoreColumns()
+    const tds = tr.querySelectorAll('td')
+    const emoji = tds[0].textContent
+    const name = tds[1].textContent
+    const unicode = tds[2].textContent
+    const charName = tds[3].textContent
+    const xml = tds[4].textContent
+    // find language code
+    let listheader = tr.previousElementSibling
+    while (listheader && listheader.className.indexOf('listheader') === -1) {
+      listheader = listheader.previousElementSibling
+    }
+    const modal = document.querySelector('.modal')
+
+    modal.querySelector('.emoji').textContent = emoji
+    modal.querySelector('.name').textContent = name
+    modal.querySelector('.unicode').textContent = unicode
+    modal.querySelector('.charname').textContent = charName
+    modal.querySelector('.xml').textContent = xml
+    modal.querySelector('.example .emojize').innerHTML = examplePythonCode('emojize', name, listheader.dataset.languageArg)
+    modal.querySelector('.example .demojize').innerHTML = examplePythonCode('demojize', emoji, listheader.dataset.languageArg)
+
+    window.setTimeout(function () {
+      modal.style.display = 'block'
+    }, 100)
+  }
+}
+
+let moreColumnsLoaded = false
+function loadMoreColumns () {
+  if (!moreColumnsLoaded) {
+    // Fill missing columns in table
+    document.querySelectorAll('#emoji_table tr>td:nth-child(3)').forEach(function (td) {
+      const tdU32 = td.parentNode.appendChild(document.createElement('td'))
+      tdU32.textContent = xmlFromPython32(td.textContent)
+    })
+    moreColumnsLoaded = true
+  }
+}
+
+function xmlFromPython32 (s) {
+  return s.trim().split('\\').slice(1).map(c => `&#${parseInt(c.substring(1), 16)};`).join('')
+}
+
+function toggleMoreColums () {
+  if (document.getElementById('enable_more_columns').checked) {
+    loadMoreColumns()
+    document.getElementById('emoji_table').classList.add('allcolumns')
+  } else {
+    document.getElementById('emoji_table').classList.remove('allcolumns')
+  }
+}
+
+function wordsInText (words, text) {
+  let matches = 0
+  for (const word of words) {
+    matches += (text.indexOf(word) !== -1)
+  }
+  return matches === words.length
+}
+
+let searchTimeOut = null
+let lastSearchParameters = null
+let enabledLists = {}
+function searchFullHandler () {
+  return new Promise(function downloadCrossSiteImage (resolve) {
+    window.clearTimeout(searchTimeOut)
+    const query = document.getElementById('search_full').value
+    searchTimeOut = window.setTimeout(() => searchFull(query, resolve), 500)
+  })
+}
+
+let searchCache = null
+function buildSearchCache () {
+  searchCache = []
+  document.querySelectorAll('#emoji_table tr').forEach(function (tr, i) {
+    if (tr.className.indexOf('header') === -1) {
+      searchCache.push({
+        tr: tr,
+        text: tr.textContent.toLowerCase(),
+        list: tr.className
+      })
+    }
+  })
+}
+
+function createSpinner () {
+  if (document.querySelector('.spinnerholder .roundspinner')) {
+    document.querySelector('.spinnerholder').style.display = 'inline-block'
+    return
+  }
+
+  const spinnerHolder = document.createElement('div')
+  spinnerHolder.classList.add('spinnerholder')
+  const spinner = spinnerHolder.appendChild(document.createElement('div'))
+  spinner.classList.add('roundspinner')
+
+  const oldSpinnerHolder = document.querySelector('.spinnerholder')
+  oldSpinnerHolder.parentNode.replaceChild(spinnerHolder, oldSpinnerHolder)
+}
+
+function hideSpinner () {
+  if (document.querySelector('.spinnerholder')) {
+    document.querySelector('.spinnerholder').style.display = 'none'
+  }
+}
+
+function searchFull (query, onDoneCallback) {
+  // Full text search in the table
+  searchTimeOut = null
+
+  createSpinner()
+
+  if (searchCache == null) {
+    buildSearchCache()
+  }
+  const searchWords = query.toLowerCase().split(/\s+/)
+
+  enabledLists = {}
+
+  const table = document.getElementById('emoji_table')
+
+  document.querySelectorAll('input[id^=enable_list_]').forEach(function (e) {
+    if (e.checked) {
+      enabledLists[e.dataset.name] = true
+      const tr = table.querySelector(`tr.listheader.${e.dataset.name}`)
+      if (tr) {
+        tr.style.display = ''
+      }
+    } else {
+      const tr = table.querySelector(`tr.listheader.${e.dataset.name}`)
+      if (tr) {
+        tr.style.display = 'none'
+      }
+    }
+  })
+
+  if (lastSearchParameters === query + '#' + Object.keys(enabledLists).join(',')) {
+    hideSpinner()
+    if (onDoneCallback) {
+      onDoneCallback()
+    }
+    return
+  }
+
+  const tableHolder = document.getElementById('emoji_table_holder')
+  const fragment = document.createDocumentFragment()
+  fragment.appendChild(table)
+
+  table.querySelectorAll('tr.empty').forEach(e => e.remove())
+
+  const onDone = function () {
+    if (tableHolder.firstElementChild) {
+      tableHolder.replaceChild(fragment, tableHolder.firstElementChild)
+    } else {
+      tableHolder.appendChild(fragment)
+    }
+    lastSearchParameters = query + '#' + Object.keys(enabledLists).join(',')
+    hideSpinner()
+    if (onDoneCallback) {
+      onDoneCallback()
+    }
+  }
+
+  window.setTimeout(() => searchFullWorker(searchWords, 0, 0, 4000, onDone))
+}
+
+function searchFullWorker (searchWords, startIndex, hiddenNodesCounter, batchSize, cb) {
+  const endIndex = Math.min(startIndex + batchSize, searchCache.length)
+  const emptyTr = document.createElement('tr')
+  emptyTr.classList.add('empty')
+  for (let i = startIndex; i < endIndex; i++) {
+    const entry = searchCache[i]
+    if (!(entry.list in enabledLists)) {
+      entry.tr.style.display = 'none'
+    } else if (!searchWords.length || wordsInText(searchWords, entry.text)) {
+      entry.tr.style.display = ''
+      if (hiddenNodesCounter > 0 && hiddenNodesCounter % 2 === 1) {
+        // Insert an empty node to correct the odd/even css behaviour
+        entry.tr.parentNode.insertBefore(emptyTr.cloneNode(false), entry.tr)
+        hiddenNodesCounter = 0
+      }
+    } else {
+      entry.tr.style.display = 'none'
+      hiddenNodesCounter++
+    }
+  }
+
+  if (endIndex < searchCache.length - 1) {
+    window.setTimeout(() => searchFullWorker(searchWords, endIndex, hiddenNodesCounter, batchSize, cb))
+  } else if (cb) {
+    cb()
+  }
+}

--- a/utils/gh-pages/requirements.txt
+++ b/utils/gh-pages/requirements.txt
@@ -1,0 +1,2 @@
+django>=3.1.0
+django-htmlmin>=0.11.0

--- a/utils/gh-pages/template.html
+++ b/utils/gh-pages/template.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>emoji overview</title>
+  <meta name="description" content="Overview of all emoji made availabe by the carpedm20/emoji python package. Search through all emoji and copy their unicode, HTML entities or python code">
+  <meta property="og:image" content="https://raw.githubusercontent.com/carpedm20/emoji/master/example/example.png">
+
+  <link rel="stylesheet" href="main.css">
+  <script src="main.js"></script>
+</head>
+
+<body>
+
+<h1>List of all emojis in the <a href="https://github.com/carpedm20/emoji">emoji</a> python package</h1>
+
+<div class="controls">
+  <div class="spinnerholder"></div>
+  <div class="search"><span class="search_icon">🔍</span><input type="text" id="search_full" placeholder="Search" /></div>
+  <br>
+  {% for entry in lists %}
+    <input type="checkbox" id="enable_list_{{ entry.name }}" data-name="{{ entry.name }}" {% if entry.name == defaultListName %} checked {% endif %} {% if not entry.emojis %} class="notloaded" {% endif %} title="{{ entry.name }}">
+    <label for="enable_list_{{ entry.name }}" title="{{ entry.name }}">{{ entry.pretty }}</label>
+  {% endfor %}
+  <br>
+  <input type="checkbox" id="enable_more_columns"><label for="enable_more_columns">Show more columns</label>
+
+</div>
+
+<div id="emoji_table_holder">
+<table id="emoji_table">
+  <tr class="header">
+    <th>emoji</th>
+    <th>name</th>
+    <th>unicode</th>
+    <th>char name</th>
+    <th>xml/html</th>
+  </tr>
+  {% for entry in lists %}
+  {% if entry.emojis %}
+    <tr class="{{ entry.name }} listheader" data-language-arg="{{ entry.languageArg }}">
+      <th>{{ entry.pretty }}</th>
+      <th colspan="5">{{ entry.name }}</th>
+    </tr>
+    {% for emoji in entry.emojis %}
+      <tr class="{{ entry.name }}">
+        <td>{{ emoji.code }}</td>
+        <td>{{ emoji.name }}</td>
+        <td>{{ emoji.unicode }}</td>
+        <td>{{ emoji.charname }}</td>
+      </tr>
+    {% endfor %}
+  {% else %}
+    <!-- Omitted {{ entry.name }} because no emojis were found -->
+  {% endif %}
+  {% endfor %}
+
+  <tr class="headerend">
+    <th colspan="6">The end. No more results.</th>
+  </tr>
+</table>
+</div>
+
+<div class="modal" style="display:none">
+  <div class="content">
+    <samp class="emoji copiable"></samp>
+    <samp class="name copiable"></samp>
+    Python unicode: <samp class="unicode copiable"></samp>
+    Python unicode name: <samp class="charname copiable"></samp>
+    XML/HTML: <samp class="xml copiable"></samp>
+    Python example: <div class="example"><code class="code emojize copiable"></code><code class="demojize copiable"></code></div>
+  </div>
+</div>
+
+<div class="footer">
+  <a href="https://github.com/carpedm20/">github</a> / <a href="https://pypi.org/project/emoji/">pypi</a>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This can generate a website that contains all table of all emoji that are currently supported by the package. The website can be deployed to github pages.

See here: https://cvzi.github.io/emoji/

It should look like this:
![emoji_overview](https://user-images.githubusercontent.com/8470684/112692460-45532600-8e7f-11eb-8144-a0a5323f0c1e.png)


To generate the html files (index.html and all.html) run:
```bash
pip install -r utils/gh-pages/requirements.txt
python utils/gh-pages/generatePages.py
```

The github action (in [updateGithubPages.yml](https://github.com/cvzi/emoji/blob/master/.github/workflows/updateGithubPages.yml)) will automatically update the HTML after every release and push the changes to the branch 'gh-pages' (this is the default place for the Github Pages). This action can also be run manually in the actions tab of the repository.