### PR TITLE
Fix some of the French emoji names not being matched

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -55,7 +55,7 @@ def emojize(
         Python is fun ❤️ #red heart, not black heart
     """
     EMOJI_UNICODE = unicode_codes.EMOJI_UNICODE[language]
-    pattern = re.compile(u'(%s[A-zÀ-ÿ0-9\\-_&.’”“()!#*+?–]+%s)' % delimiters)
+    pattern = re.compile(u'(%s[\\w\\-&.’”“()!#*+?–,/]+%s)' % delimiters)
 
     def replace(match):
         mg = match.group(1).replace(delimiters[0], _DEFAULT_DELIMITER).replace(


### PR DESCRIPTION
Some of the characters used in the French emoji names are currently not included in the regular expression for matching emoji names. One example is œ.

As word characters aren't continuous in Unicode it is impossible to correctly match them via a range expression. Thus, I converted the existing range to the word characters group which should be future proof regarding additional languages and avoids accidentally including non-word characters that could have been included by an overly vast range.