### PR TITLE
Fix matching of non-ASCII emoji names on Python 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 emoji
 =====
 
+UNRELEASED
+----------
+
+* Fix matching of non-ASCII emoji names on Python 2
+
 1.4.2
 -----
 * Delimiter for German time naming changed from ":" to "."

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -55,7 +55,7 @@ def emojize(
         Python is fun ❤️ #red heart, not black heart
     """
     EMOJI_UNICODE = unicode_codes.EMOJI_UNICODE[language]
-    pattern = re.compile(u'(%s[\\w\\-&.’”“()!#*+?–,/]+%s)' % delimiters)
+    pattern = re.compile(u'(%s[\\w\\-&.’”“()!#*+?–,/]+%s)' % delimiters, flags=re.UNICODE)
 
     def replace(match):
         mg = match.group(1).replace(delimiters[0], _DEFAULT_DELIMITER).replace(


### PR DESCRIPTION
The fix in  PR #178 was sadly incomplete as it only worked on Python 3 but not on Python 2.