### PR TITLE
Readme and github pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Example
 
 The entire set of Emoji codes as defined by the `unicode consortium <http://www.unicode.org/Public/emoji/1.0/full-emoji-list.html>`__
 is supported in addition to a bunch of `aliases <http://www.emoji-cheat-sheet.com/>`__.  By
-default, only the official list is enabled but doing ``emoji.emojize(use_aliases=True)`` enables
+default, only the official list is enabled but doing ``emoji.emojize(language='alias')`` enables
 both the full list and aliases.
 
 .. code-block:: python
@@ -17,13 +17,13 @@ both the full list and aliases.
     >> import emoji
     >> print(emoji.emojize('Python is :thumbs_up:'))
     Python is 👍
-    >> print(emoji.emojize('Python is :thumbsup:', use_aliases=True))
+    >> print(emoji.emojize('Python is :thumbsup:', language='alias'))
     Python is 👍
     >> print(emoji.demojize('Python is 👍'))
     Python is :thumbs_up:
     >>> print(emoji.emojize("Python is fun :red_heart:"))
     Python is fun ❤
-    >>> print(emoji.emojize("Python is fun :red_heart:",variant="emoji_type"))
+    >>> print(emoji.emojize("Python is fun :red_heart:", variant="emoji_type"))
     Python is fun ❤️ #red heart, not black heart
     >>> print(emoji.is_emoji("👍"))
     True

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -8,9 +8,9 @@ emoji for Python
 emoji terminal output for Python.
 
     >>> import emoji
-    >>> print(emoji.emojize('Python is :thumbsup:', use_aliases=True))
+    >>> print(emoji.emojize('Python is :thumbsup:', language='alias'))
     Python is 👍
-    >> print(emoji.emojize('Python is :thumbs_up:'))
+    >>> print(emoji.emojize('Python is :thumbs_up:'))
     Python is 👍
 """
 

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -21,7 +21,7 @@ from emoji.unicode_codes import *
 __all__ = [
     # emoji.core
     'emojize', 'demojize', 'get_emoji_regexp', 'emoji_count', 'emoji_lis',
-    'replace_emoji', 'version',
+    'distinct_emoji_lis', 'replace_emoji', 'version', 'is_emoji',
     # emoji.unicode_codes
     'EMOJI_UNICODE_ENGLISH', 'EMOJI_UNICODE_SPANISH', 'EMOJI_UNICODE_PORTUGUESE',
     'EMOJI_UNICODE_ITALIAN', 'EMOJI_UNICODE_FRENCH', 'EMOJI_UNICODE_GERMAN',

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -39,7 +39,7 @@ def emojize(
 ):
     """Replace emoji names in a string with unicode codes.
         >>> import emoji
-        >>> print(emoji.emojize("Python is fun :thumbsup:", use_aliases=True))
+        >>> print(emoji.emojize("Python is fun :thumbsup:", language='alias'))
         Python is fun 👍
         >>> print(emoji.emojize("Python is fun :thumbs_up:"))
         Python is fun 👍

--- a/utils/gh-pages/requirements.txt
+++ b/utils/gh-pages/requirements.txt
@@ -1,2 +1,2 @@
-django>=3.1.0
+django>=4.0.1
 django-htmlmin>=0.11.0

--- a/utils/gh-pages/template.html
+++ b/utils/gh-pages/template.html
@@ -21,7 +21,7 @@
   <div class="search"><span class="search_icon">🔍</span><input type="text" id="search_full" placeholder="Search" /></div>
   <br>
   {% for entry in lists %}
-    <input type="checkbox" id="enable_list_{{ entry.name }}" data-name="{{ entry.name }}" {% if entry.name == defaultListName %} checked {% endif %} {% if not entry.emojis %} class="notloaded" {% endif %} title="{{ entry.name }}">
+    <input type="checkbox" id="enable_list_{{ entry.name }}" data-name="{{ entry.name }}" {% if entry.name == defaultLang %} checked {% endif %} {% if not entry.emojis %} class="notloaded" {% endif %} title="{{ entry.name }}">
     <label for="enable_list_{{ entry.name }}" title="{{ entry.name }}">{{ entry.pretty }}</label>
   {% endfor %}
   <br>


### PR DESCRIPTION
*  Replace `use_aliases=True` with `language='alias'` in README and Github pages

*  I somehow broke the github pages, because currently the page starts with no language selected. Now the `'en'` checkbox will be selected by default. https://carpedm20.github.io/emoji/ vs https://cvzi.github.io/emoji/

