### PR TITLE
Don't use deprecated emoji_lis functions in emoji_count

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -364,8 +364,8 @@ def emoji_count(string, unique=False):
     :param unique: (optional) True if count only unique emojis
     """
     if unique:
-        return len(distinct_emoji_lis(string))
-    return len(emoji_lis(string))
+        return len(distinct_emoji_list(string))
+    return len(emoji_list(string))
 
 
 def is_emoji(string):

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -4,7 +4,6 @@
 """Unittests for deprecation warnings"""
 
 import sys
-
 import emoji
 import pytest
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -4,6 +4,7 @@
 """Unittests for deprecation warnings"""
 
 import sys
+
 import emoji
 import pytest
 
@@ -39,9 +40,9 @@ def test_deprecation_distinct_emoji_lis():
 
 @pytest.mark.filterwarnings("error")
 def test_deprecation_emojize_use_aliases():
-    with pytest.warns(DeprecationWarning) :
+    with pytest.warns(DeprecationWarning):
         emoji.emojize("test", True)
-    with pytest.warns(DeprecationWarning) :
+    with pytest.warns(DeprecationWarning):
         emoji.emojize("test", use_aliases=True)
     with pytest.warns(DeprecationWarning):
         emoji.emojize("test", use_aliases=False)
@@ -72,6 +73,6 @@ def test_deprecation_module_variables():
     if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
         with pytest.warns(DeprecationWarning):
             for _ in emoji.EMOJI_UNICODE_ENGLISH:
-             pass
+                pass
     for _ in emoji.EMOJI_DATA:
         pass


### PR DESCRIPTION
In version 1.7.0, `emoji_count()` uses the deprecated functions `distinct_emoji_lis()` and `emoji_lis()`. This changes to their newly added `*emoji_list()` versions. Also fixes some minor spacing issues in `tests/test_deprecation.py`.