### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/updateGithubPages.yml
+++ b/.github/workflows/updateGithubPages.yml
@@ -54,7 +54,7 @@ jobs:
         mv ../gh-pages/all.html .
         mv ../gh-pages/main.css .
         mv ../gh-pages/main.js .
-        rm -R docs
+        rm -R docs || true
         mv ../docs/_build/html docs
         touch .nojekyll
     - name: git commit & push


### PR DESCRIPTION
This should prevent the crash `rm: cannot remove 'docs': No such file or directory`
#210