### PR TITLE
Fix delimiters

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -38,7 +38,7 @@ def emojize(
         Python is fun 👍
         >>> print(emoji.emojize("Python is fun :thumbs_up:"))
         Python is fun 👍
-        >>> print(emoji.emojize("Python is fun __thumbs_up__", delimiters = ("__", "__")))
+        >>> print(emoji.emojize("Python is fun {thumbs_up}", delimiters = ("{", "}")))
         Python is fun 👍
         >>> print(emoji.emojize("Python is fun :red_heart:", variant="text_type"))
         Python is fun ❤
@@ -46,7 +46,8 @@ def emojize(
         Python is fun ❤️ # red heart, not black heart
 
     :param string: String contains emoji names.
-    :param delimiters: (optional) Use delimiters other than _DEFAULT_DELIMITER
+    :param delimiters: (optional) Use delimiters other than _DEFAULT_DELIMITER. Each delimiter
+        should contain at least one character that is not part of a-zA-Z0-9 and ``_-–&.’”“()!?#*+,/\``
     :param variant: (optional) Choose variation selector between "base"(None), VS-15 ("text_type") and VS-16 ("emoji_type")
     :param language: Choose language of emoji name: language code 'es', 'de', etc. or 'alias'
         to use English aliases
@@ -78,7 +79,7 @@ def emojize(
         language_pack = unicode_codes.get_emoji_unicode_dict(language)
 
     pattern = re.compile(u'(%s[\\w\\-&.’”“()!#*+?–,/]+%s)' %
-                         delimiters, flags=re.UNICODE)
+                         (re.escape(delimiters[0]), re.escape(delimiters[1])), flags=re.UNICODE)
 
     def replace(match):
         mg = match.group(1)[len(delimiters[0]):-len(delimiters[1])]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -222,20 +222,22 @@ def test_demojize_complicated_string():
 
 def test_demojize_delimiters():
     for e in [u'\U000026BD', u'\U0001f44d', u'\U0001F3C8']:
-        for d in [(":", ":"), ("a", "b"), ("!", "!!"), ("123", "456"), (u"😁", u"👌")]:
+        for d in [(":", ":"), ("}", "}"), ("!$", "!!$"), ("[123", "456]"), (u"😁", u"👌"), ("[", "]")]:
             s = emoji.demojize(e, delimiters=d)
             assert s.startswith(d[0])
             assert s.endswith(d[1])
 
-    text = u"Example of a text with an emoji%sin a sentence"
+    text = u"Example with an emoji%sin a sentence and %s %s %s %s multiple emoji %s%s%s%s%s in a row"
     for e in [u'\U000026BD', u'\U0001f44d', u'\U0001F3C8']:
-        for d in [(":", ":"), ("!", "-!-"), ("-", "-"), (":", "::"), ("::", "::"), (u"😁", u"👌")]:
-            text_with_unicode = text % e
+        for d in [(":", ":"), ("{", "}"), ("!$", "$!"), (":", "::"), ("::", "::"), (u"😁", u"👌"), ("[", "]")]:
+            print("delimiter: %s" % (d, ))
+            text_with_unicode = text % ((e, ) * 10)
             demojized_text = emoji.demojize(text_with_unicode, delimiters=d)
-            assert text_with_unicode != demojized_text
+            assert text_with_unicode != demojized_text, (text_with_unicode, demojized_text)
             assert e not in demojized_text
             assert emoji.emojize(demojized_text, delimiters=d) == text_with_unicode
-            text_with_emoji = text % emoji.demojize(e, delimiters=d)
+            de = emoji.demojize(e, delimiters=d)
+            text_with_emoji = text % ((de, ) * 10)
             assert demojized_text == text_with_emoji
             assert emoji.emojize(text_with_emoji, delimiters=d) == text_with_unicode
 


### PR DESCRIPTION
* Escape delimiters with `re.escape` #213
* Change documentation and tests of delimiters

When I changed the tests to catch the error from #213, I realized that regardless of that problem not all delimiters work:

Delimiters work correctly, if they contain at least one character that is not part of the regular expression `[\\w\\-&.’”“()!#*+?–,/]+`. 
If the delimiters consist only of characters that are part of the regular expression, then the regular expression will also capture the delimiters of the next emoji if there are multiple emojis in a row:
```python
emoji.emojize('!star!!star!', delimiters=('!', '!'))
# '!star!!star!'
emoji.emojize('!star! !star!', delimiters=('!', '!'))
# '⭐ ⭐'
emoji.emojize('!star!test!star!', delimiters=('!', '!'))
# '!star!test!star!'
``` 

Example for delimiters:
* `!` does not work, because it is part of the regular expression
* `:!` works because `:` is not part of the regular expression
* `![` works because `[` is not part of the regular expression
* `!-` won't work because both `!` and `-` are part of the regular expression

I don't know how to fix this, so for now I added an explanation to the documentation of the delimiters parameter.


