### PR TITLE
Add Trove classifiers for Python 3.10 and 3.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,4 +111,4 @@ emoji
 * Added ~400 codes to bring the emoji list up to date
 * emojize() regex now matches &.ô’Åéãíç
 * Unittests for API and to validate emoji formatting and parsing
-* decode() function to lookup emoji by their unicode code
+* decode() function to lookup emoji by their Unicode code

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Emoji for Python.  This project was inspired by `kyokomi <https://github.com/kyo
 Example
 -------
 
-The entire set of Emoji codes as defined by the `unicode consortium <https://unicode.org/emoji/charts/full-emoji-list.html>`__
+The entire set of Emoji codes as defined by the `Unicode consortium <https://unicode.org/emoji/charts/full-emoji-list.html>`__
 is supported in addition to a bunch of `aliases <https://www.webfx.com/tools/emoji-cheat-sheet/>`__.  By
 default, only the official list is enabled but doing ``emoji.emojize(language='alias')`` enables
 both the full list and aliases.
@@ -100,7 +100,7 @@ Links
 
 `Emoji Cheat Sheet <https://www.webfx.com/tools/emoji-cheat-sheet/>`__
 
-`Official unicode list <http://www.unicode.org/emoji/charts/full-emoji-list.html>`__
+`Official Unicode list <http://www.unicode.org/emoji/charts/full-emoji-list.html>`__
 
 **For Spanish:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 | **Module contents**                                                                           |                                                              |
 |-----------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| [`emojize()`](https://carpedm20.github.io/emoji/docs/#emoji.emojize)                          | Replace emoji names in with unicode codes                    |
-| [`demojize()`](https://carpedm20.github.io/emoji/docs/#emoji.demojize)                        | Replace unicode emoji with emoji shortcodes                  |
-| [`replace_emoji()`](https://carpedm20.github.io/emoji/docs/#emoji.replace_emoji)              | Replace unicode emoji with a customizable string             |
+| [`emojize()`](https://carpedm20.github.io/emoji/docs/#emoji.emojize)                          | Replace emoji names in with Unicode codes                    |
+| [`demojize()`](https://carpedm20.github.io/emoji/docs/#emoji.demojize)                        | Replace Unicode emoji with emoji shortcodes                  |
+| [`replace_emoji()`](https://carpedm20.github.io/emoji/docs/#emoji.replace_emoji)              | Replace Unicode emoji with a customizable string             |
 | [`emoji_list()`](https://carpedm20.github.io/emoji/docs/#emoji.emoji_list)                    | Location of all emoji in a string                            |
 | [`distinct_emoji_list()`](https://carpedm20.github.io/emoji/docs/#emoji.distinct_emoji_list)  | Distinct list of emojis in the string                        |
 | [`emoji_count()`](https://carpedm20.github.io/emoji/docs/#emoji.emoji_count)                  | Number of emojis in a string                                 |

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,11 +12,11 @@ API Reference
 +=============================+==============================================================+
 | **Functions:**              |                                                              |
 +-----------------------------+--------------------------------------------------------------+
-| :func:`emojize`             | Replace emoji names with unicode codes                       |
+| :func:`emojize`             | Replace emoji names with Unicode codes                       |
 +-----------------------------+--------------------------------------------------------------+
-| :func:`demojize`            | Replace unicode emoji with emoji shortcodes                  |
+| :func:`demojize`            | Replace Unicode emoji with emoji shortcodes                  |
 +-----------------------------+--------------------------------------------------------------+
-| :func:`replace_emoji`       | Replace unicode emoji with a customizable string             |
+| :func:`replace_emoji`       | Replace Unicode emoji with a customizable string             |
 +-----------------------------+--------------------------------------------------------------+
 | :func:`emoji_list`          | Location of all emoji in a string                            |
 +-----------------------------+--------------------------------------------------------------+
@@ -49,7 +49,7 @@ EMOJI_DATA
    :type: dict
    :canonical: emoji.unicode_codes.data_dict.EMOJI_DATA
 
-     Contains all emoji as keys and their names, unicode version and status
+     Contains all emoji as keys and their names, Unicode version and status
 
      .. code-block:: python
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ html_theme_options = {
     'canonical_url': 'https://carpedm20.github.io/emoji/docs/',
     'extra_nav_links': {
         'Github repository' : 'https://github.com/carpedm20/emoji',
-        'emoji on PyPi' : 'https://pypi.org/project/emoji/',
+        'emoji on PyPI' : 'https://pypi.org/project/emoji/',
         'All supported emoji' : 'https://carpedm20.github.io/emoji/',
         'All emoji on unicode.org' : 'http://www.unicode.org/emoji/charts/full-emoji-list.html',
         'Unicode Standard' : 'http://www.unicode.org/reports/tr51/',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ html_theme_options = {
     'show_related': False,
     'canonical_url': 'https://carpedm20.github.io/emoji/docs/',
     'extra_nav_links': {
-        'Github repository' : 'https://github.com/carpedm20/emoji',
+        'GitHub repository' : 'https://github.com/carpedm20/emoji',
         'emoji on PyPI' : 'https://pypi.org/project/emoji/',
         'All supported emoji' : 'https://carpedm20.github.io/emoji/',
         'All emoji on unicode.org' : 'http://www.unicode.org/emoji/charts/full-emoji-list.html',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,10 +25,10 @@ emoji supports Python 2.7 and 3.4+
 Usage and Examples
 ------------------
 
-The main purpose of this package is converting unicode emoji to emoji names and vice
+The main purpose of this package is converting Unicode emoji to emoji names and vice
 versa with :func:`emojize` and :func:`demojize`.
 
-The entire set of Emoji codes as defined by the `unicode consortium <https://unicode.org/emoji/charts/full-emoji-list.html>`__
+The entire set of Emoji codes as defined by the `Unicode consortium <https://unicode.org/emoji/charts/full-emoji-list.html>`__
 is supported in addition to a bunch of `aliases <https://www.webfx.com/tools/emoji-cheat-sheet/>`__.
 By default, only the official list is enabled but doing ``emoji.emojize(language='alias')``
 enables both the full list and aliases.
@@ -251,7 +251,7 @@ The function ``get_emoji_regexp()`` was removed in 2.0.0. Internally the module 
 a regular expression when scanning for emoji in a string (e.g. in :func:`demojize`).
 
 The regular expression was slow in Python 3 and it failed to correctly find certain combinations
-of long emoji (emoji consisting of multiple unicode codepoints).
+of long emoji (emoji consisting of multiple Unicode codepoints).
 
 If you used the regular expression to remove emoji from strings, you can use :func:`replace_emoji`
 as shown in the examples above.
@@ -297,7 +297,7 @@ Common problems
 
 This exception is thrown in Python 2.7 if you passed a ``str`` string instead of a
 ``unicode`` string.
-You should only pass unicode strings to this module.
+You should only pass Unicode strings to this module.
 
 See https://python.readthedocs.io/en/v2.7.2/howto/unicode.html#the-unicode-type for more
 information on Unicode in Python 2.7.
@@ -318,11 +318,11 @@ Reference documentation of all functions and properties in the module:
 +=============================+==============================================================+
 | **Functions:**              |                                                              |
 +-----------------------------+--------------------------------------------------------------+
-| :func:`emojize`             | Replace emoji names with unicode codes                       |
+| :func:`emojize`             | Replace emoji names with Unicode codes                       |
 +-----------------------------+--------------------------------------------------------------+
-| :func:`demojize`            | Replace unicode emoji with emoji shortcodes                  |
+| :func:`demojize`            | Replace Unicode emoji with emoji shortcodes                  |
 +-----------------------------+--------------------------------------------------------------+
-| :func:`replace_emoji`       | Replace unicode emoji with a customizable string             |
+| :func:`replace_emoji`       | Replace Unicode emoji with a customizable string             |
 +-----------------------------+--------------------------------------------------------------+
 | :func:`emoji_list`          | Location of all emoji in a string                            |
 +-----------------------------+--------------------------------------------------------------+
@@ -357,7 +357,7 @@ Links
 
 `Emoji Cheat Sheet <https://www.webfx.com/tools/emoji-cheat-sheet/>`__
 
-`Official unicode list <http://www.unicode.org/emoji/charts/full-emoji-list.html>`__
+`Official Unicode list <http://www.unicode.org/emoji/charts/full-emoji-list.html>`__
 
 **For Spanish:**
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Via pip:
 
     $ pip install emoji --upgrade
 
-See https://pypi.org/project/emoji/ for more information on pip and PyPi
+See https://pypi.org/project/emoji/ for more information on pip and PyPI
 
 From master branch:
 

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -32,7 +32,7 @@ def emojize(
         handle_version=None
 ):
     """
-    Replace emoji names in a string with unicode codes.
+    Replace emoji names in a string with Unicode codes.
         >>> import emoji
         >>> print(emoji.emojize("Python is fun :thumbsup:", language='alias'))
         Python is fun 👍
@@ -55,7 +55,7 @@ def emojize(
         all emoji above this version will be ignored.
     :param handle_version: (optional) Replace the emoji above ``version``
         instead of ignoring it. handle_version can be either a string or a
-        callable; If it is a callable, it's passed the unicode emoji and the
+        callable; If it is a callable, it's passed the Unicode emoji and the
         data dict from emoji.EMOJI_DATA and must return a replacement string
         to be used::
 
@@ -124,7 +124,7 @@ def demojize(
         handle_version=None
 ):
     """
-    Replace unicode emoji in a string with emoji shortcodes. Useful for storage.
+    Replace Unicode emoji in a string with emoji shortcodes. Useful for storage.
         >>> import emoji
         >>> print(emoji.emojize("Python is fun :thumbs_up:"))
         Python is fun 👍
@@ -133,7 +133,7 @@ def demojize(
         >>> print(emoji.demojize(u"Unicode is tricky 😯", delimiters=("__", "__")))
         Unicode is tricky __hushed_face__
 
-    :param string: String contains unicode characters. MUST BE UNICODE.
+    :param string: String contains Unicode characters. MUST BE UNICODE.
     :param delimiters: (optional) User delimiters other than ``_DEFAULT_DELIMITER``
     :param language: Choose language of emoji name: language code 'es', 'de', etc. or 'alias'
         to use English aliases
@@ -142,7 +142,7 @@ def demojize(
     :param handle_version: (optional) Replace the emoji above ``version``
         instead of removing it. handle_version can be either a string or a
         callable ``handle_version(emj: str, data: dict) -> str``; If it is
-        a callable, it's passed the unicode emoji and the data dict from
+        a callable, it's passed the Unicode emoji and the data dict from
         emoji.EMOJI_DATA and must return a replacement string  to be used.
         The passed data is in the form of::
 
@@ -214,11 +214,11 @@ def demojize(
 
 def replace_emoji(string, replace='',  version=-1):
     """
-    Replace unicode emoji in a customizable string.
+    Replace Unicode emoji in a customizable string.
 
-    :param string: String contains unicode characters. MUST BE UNICODE.
+    :param string: String contains Unicode characters. MUST BE UNICODE.
     :param replace: (optional) replace can be either a string or a callable;
-        If it is a callable, it's passed the unicode emoji and the data dict from
+        If it is a callable, it's passed the Unicode emoji and the data dict from
         emoji.EMOJI_DATA and must return a replacement string to be used.
         replace(str, dict) -> str
     :param version: (optional) Max version. If set to an Emoji Version,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     author_email=email,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ with open(os.path.join('emoji', '__init__.py'), encoding='utf-8') as f:
 setup(
     name='emoji',
     author=author,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     author_email=email,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python',

--- a/utils/get_codes_from_unicode_emoji_data_files.py
+++ b/utils/get_codes_from_unicode_emoji_data_files.py
@@ -172,7 +172,7 @@ def extract_names(xml, lang):
 
 
 def get_emoji_from_github_api() -> dict:
-    """Get emoji alias from Github API
+    """Get emoji alias from GitHub API
     """
 
     data = requests.get("https://api.github.com/emojis").json()
@@ -185,7 +185,7 @@ def get_emoji_from_github_api() -> dict:
             emj = "".join(chr(int(h, 16)) for h in m.group(1).split('-'))
             output[name] = emj
         else:
-            pass # Special Github emoji that is not part of Unicode
+            pass  # Special GitHub emoji that is not part of Unicode
 
     return output
 
@@ -257,7 +257,7 @@ if __name__ == "__main__":
             if emj_no_variant in emoji_pkg.EMOJI_DATA and 'alias' in emoji_pkg.EMOJI_DATA[emj_no_variant]:
                 aliases.update(a[1:-1] for a in emoji_pkg.EMOJI_DATA[emj_no_variant]['alias'])
 
-        # Add alias from  Github API
+        # Add alias from  GitHub API
         for gh_alias in github_alias:
             if emj == github_alias[gh_alias]:
                 aliases.add(gh_alias)

--- a/utils/gh-pages/README.rst
+++ b/utils/gh-pages/README.rst
@@ -1,14 +1,14 @@
-Emoji overview on github pages
+Emoji overview on GitHub Pages
 ==============================
 
 Generate a HTML website that contains all emoji and names that are currently supported.
 
-Github pages
--------------
+GitHub Pages
+------------
 
 https://carpedm20.github.io/emoji/
 
-On every release the content on the github pages is updated by a github action:
+On every release the content on the GitHub Pages is updated by a GitHub Action:
 `updateGithubPages.yml <../../.github/workflows/updateGithubPages.yml>`__.
 
 You can view the generated source in the `gh-pages <https://github.com/carpedm20/emoji/tree/gh-pages>`__ branch.

--- a/utils/gh-pages/template.html
+++ b/utils/gh-pages/template.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>emoji overview</title>
-  <meta name="description" content="Overview of all emoji made availabe by the carpedm20/emoji python package. Search through all emoji and copy their unicode, HTML entities or python code">
+  <meta name="description" content="Overview of all emoji made availabe by the carpedm20/emoji python package. Search through all emoji and copy their Unicode, HTML entities or python code">
   <meta property="og:image" content="https://raw.githubusercontent.com/carpedm20/emoji/master/example/example.png">
 
   <link rel="stylesheet" href="main.css">
@@ -34,7 +34,7 @@
   <tr class="header">
     <th>emoji</th>
     <th>name</th>
-    <th>unicode</th>
+    <th>Unicode</th>
     <th>char name</th>
     <th>xml/html</th>
   </tr>
@@ -67,8 +67,8 @@
   <div class="content">
     <samp class="emoji copiable"></samp>
     <samp class="name copiable"></samp>
-    Python unicode: <samp class="unicode copiable"></samp>
-    Python unicode name: <samp class="charname copiable"></samp>
+    Python Unicode: <samp class="unicode copiable"></samp>
+    Python Unicode name: <samp class="charname copiable"></samp>
     XML/HTML: <samp class="xml copiable"></samp>
     Python example: <div class="example"><code class="code emojize copiable"></code><code class="demojize copiable"></code></div>
   </div>

--- a/utils/gh-pages/template.html
+++ b/utils/gh-pages/template.html
@@ -75,7 +75,7 @@
 </div>
 
 <div class="footer">
-  <a href="https://github.com/carpedm20/emoji">github</a> / <a href="https://pypi.org/project/emoji/">pypi</a> / <a href="https://carpedm20.github.io/emoji/docs/">documentation</a>
+  <a href="https://github.com/carpedm20/emoji">github</a> / <a href="https://pypi.org/project/emoji/">PyPI</a> / <a href="https://carpedm20.github.io/emoji/docs/">documentation</a>
 </div>
 
 </body>

--- a/utils/gh-pages/template.html
+++ b/utils/gh-pages/template.html
@@ -75,7 +75,7 @@
 </div>
 
 <div class="footer">
-  <a href="https://github.com/carpedm20/emoji">github</a> / <a href="https://pypi.org/project/emoji/">PyPI</a> / <a href="https://carpedm20.github.io/emoji/docs/">documentation</a>
+  <a href="https://github.com/carpedm20/emoji">GitHub</a> / <a href="https://pypi.org/project/emoji/">PyPI</a> / <a href="https://carpedm20.github.io/emoji/docs/">documentation</a>
 </div>
 
 </body>


### PR DESCRIPTION
* Add Trove classifiers for Python 3.10 and 3.11
* Add `python_requires` to help pip
* Fix some typos: Unicode, PyPI and GitHub