### PR TITLE
Added missed `py.typed` `package_data`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     license="New BSD",
     long_description=readme_content,
     packages=['emoji', 'emoji.unicode_codes'],
+    package_data={"emoji": ["py.typed"]},
     url=source,
     version=version,
     zip_safe=True,


### PR DESCRIPTION
#166 forgot to add the `py.typed` marker to the package.