### PR TITLE
Test 3.11 final and 3.12-dev

### DIFF
--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 8
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-alpha - 3.11.0"]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.11.1 is out, let's just say `3.11` to test the latest.

And we can also now test `3.12-dev`.

---

And maybe it's time to drop EOL Python 2.7, 3.5 and 3.6?

It would allow modernising the code to use newer features, and reduce the resources used by the CI.

| cycle |  release   | latest | latest release |    eol     |
|:------|:----------:|:-------|:--------------:|:----------:|
| 3.11  | 2022-10-24 | 3.11.1 |   2022-12-06   | 2027-10-24 |
| 3.10  | 2021-10-04 | 3.10.9 |   2022-12-06   | 2026-10-04 |
| 3.9   | 2020-10-05 | 3.9.16 |   2022-12-06   | 2025-10-05 |
| 3.8   | 2019-10-14 | 3.8.16 |   2022-12-06   | 2024-10-14 |
| 3.7   | 2018-06-26 | 3.7.16 |   2022-12-06   | 2023-06-27 |
| 3.6   | 2016-12-22 | 3.6.15 |   2021-09-03   | 2021-12-23 |
| 3.5   | 2015-09-12 | 3.5.10 |   2020-09-05   | 2020-09-13 |
| 2.7   | 2010-07-03 | 2.7.18 |   2020-04-19   | 2020-01-01 |

<img width="724" alt="image" src="https://user-images.githubusercontent.com/1324225/206931132-b3fa93a6-e0ef-481b-a6b0-539ce1cc51bd.png">

https://devguide.python.org/versions/

Here's the pip installs for emoji from PyPI for November 2022, showing they're little used:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.8      |  35.83% |   910,296 |
| null     |  27.02% |   686,344 |
| 3.7      |  18.15% |   461,176 |
| 3.9      |  11.05% |   280,759 |
| 3.10     |   4.85% |   123,270 |
| 3.6      |   1.34% |    34,155 |
| 2.7      |   0.83% |    21,086 |
| 3.11     |   0.74% |    18,677 |
| 3.5      |   0.17% |     4,417 |
| 3.12     |   0.00% |        46 |
| 3.4      |   0.00% |        19 |
| 3.3      |   0.00% |         1 |
| Total    |         | 2,540,246 |

Source: `pip install -U pypistats && pypistats python_minor emoji --last-month`
