### PR TITLE
Don't invoke setup.py directly

### DIFF
--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -28,4 +28,4 @@ jobs:
         pytest
     - name: Test install
       run: |
-        python setup.py install
+        python -m pip install .

--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install -e .[dev]
+        python -m pip install -e .[dev]
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/updateGithubPages.yml
+++ b/.github/workflows/updateGithubPages.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Install package
       run: |
         python -m pip install --upgrade pip setuptools
-        python setup.py install
+        python -m pip install .
     - name: Retain directories
       run: |
         cp -R utils/gh-pages ..

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ From master branch:
 
     $ git clone https://github.com/carpedm20/emoji.git
     $ cd emoji
-    $ python setup.py install
+    $ python -m pip install .
 
 
 Developing

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Via pip:
 
 .. code-block:: console
 
-    $ pip install emoji --upgrade
+    $ python -m pip install emoji --upgrade
 
 From master branch:
 
@@ -73,7 +73,7 @@ Developing
 
     $ git clone https://github.com/carpedm20/emoji.git
     $ cd emoji
-    $ pip install -e .\[dev\]
+    $ python -m pip install -e .\[dev\]
     $ pytest
 
 The ``utils/get-codes-from-unicode-consortium.py`` may help when updating

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Building the documentation with [Sphinx](https://www.sphinx-doc.org/):
 ```bash
 git clone https://github.com/carpedm20/emoji.git
 cd emoji/docs
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 make html
 ```
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Via pip:
 
 .. code-block:: console
 
-    $ pip install emoji --upgrade
+    $ python -m pip install emoji --upgrade
 
 See https://pypi.org/project/emoji/ for more information on pip and PyPI
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,4 +17,4 @@ From master branch:
 
     $ git clone https://github.com/carpedm20/emoji.git
     $ cd emoji
-    $ python setup.py install
+    $ python -m pip install .

--- a/utils/README.md
+++ b/utils/README.md
@@ -47,7 +47,7 @@ languages = {
 Now we run the script and store the output in `out.py`. The output is a new `EMOJI_DATA` dict
 
 ```sh
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 python utils/get_codes_from_unicode_emoji_data_files.py > out.py
 ```
 

--- a/utils/gh-pages/README.rst
+++ b/utils/gh-pages/README.rst
@@ -19,5 +19,5 @@ Build pages locally
 
 .. code-block:: sh
 
-    pip install -r utils/gh-pages/requirements.txt
+    python -m pip install -r utils/gh-pages/requirements.txt
     python utils/gh-pages/generatePages.py


### PR DESCRIPTION
Don't invoke `setup.py` directly, it's deprecated.

Short version: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary

Long version: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

---

And use `python -m pip` instead of plain `pip`. You already had this in three places in `updateGithubPages.yml`, let's do it in the others too.

Why: https://snarky.ca/why-you-should-use-python-m-pip/
