### PR TITLE
Wheel for Python 2 and 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_files = LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Typing :: Typed'
     ],
-    description="Emoji for Python",
+    description='Emoji for Python',
     keywords=['emoji'],
     extras_require={
         'dev': [
@@ -68,10 +68,19 @@ setup(
         ],
     },
     include_package_data=True,
-    license="New BSD",
+    license='New BSD',
     long_description=readme_content,
     packages=['emoji', 'emoji.unicode_codes'],
-    package_data={"emoji": ["py.typed"]},
+    package_data={
+        'emoji': [
+            'py.typed',
+            '*.pyi',
+        ],
+        'emoji.unicode_codes': [
+            'py.typed',
+            '*.pyi',
+        ],
+    },
     url=source,
     version=version,
     zip_safe=True,


### PR DESCRIPTION
Building a release:
```bash
python -m pip install --upgrade build
python -m build
``` 
Outputs wheel file to: `dist/emoji-2.2.0-py2.py3-none-any.whl`

Ref:
Fixes #247
Fixes #250 
#226

Notes:
In the future setup.py and setup.cfg can/should be replaced by a single file [pyproject.toml](https://peps.python.org/pep-0621/#example). We can do this if we decide to stop support for Python 2.7