### PR TITLE
Publish to pypi.org automatically on release

### DIFF
--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -1,0 +1,29 @@
+name: Upload Python Package to PyPi.org
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/emoji/
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade build wheel
+    - name: Build package
+      run: |
+        python -m build
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.8.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=59.6.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
@TahirJalilov This needs some configuration on Github and Pypi:

## On Github:
Create a new Environment called `pypi` (maybe this needs to be done by @carpedm20 ?):
Goto https://github.com/carpedm20/emoji/settings/environments
Click **New environment** and name it `pypi`


## On pypi.org:
Goto the "Manage"-page of the project, and select **Publishing** on the left side. 
Then fill out the form with:
```
carpedm20
emoji
pypipublish.yml
pypi
```

---
Documentation on this pypi.org-feature:
https://docs.pypi.org/trusted-publishers/adding-a-publisher/

Ref #254
