### PR TITLE
Lrucache

### DIFF
--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -9,11 +9,11 @@ on:
       - 'gh-pages'
 jobs:
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 8
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "pypy-3.10", "3.11", "3.12", "3.13-dev"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,6 +26,9 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Test with pytest (random test order)
+      run: |
+        pytest --shuffle
 
   lint:
     runs-on: ubuntu-latest

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -378,7 +378,7 @@ def version(string: str) -> float:
     emojize(string, language='alias', version=-1, handle_version=f)
     if version:
         return version[0]
-    for lang_code in unicode_codes._EMOJI_UNICODE:  # type: ignore
+    for lang_code in unicode_codes.LANGUAGES:
         emojize(string, language=lang_code, version=-1, handle_version=f)
         if version:
             return version[0]

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -120,20 +120,16 @@ def emojize(
 
     """
 
-    if language == 'alias':
-        language_pack = unicode_codes.get_aliases_unicode_dict()
-    else:
-        language_pack = unicode_codes.get_emoji_unicode_dict(language)
-
     pattern = re.compile('(%s[%s]+%s)' %
                          (re.escape(delimiters[0]), _EMOJI_NAME_PATTERN, re.escape(delimiters[1])))
 
     def replace(match: Match[str]) -> str:
         name = match.group(1)[len(delimiters[0]):-len(delimiters[1])]
-        emj = language_pack.get(
+        emj = unicode_codes.get_emoji_by_name(
             _DEFAULT_DELIMITER +
             unicodedata.normalize('NFKC', name) +
-            _DEFAULT_DELIMITER)
+            _DEFAULT_DELIMITER, language)
+
         if emj is None:
             return match.group(1)
 
@@ -360,11 +356,10 @@ def version(string: str) -> float:
     if string in unicode_codes.EMOJI_DATA:
         return unicode_codes.EMOJI_DATA[string]['E']
 
-    language_pack = unicode_codes.get_emoji_unicode_dict('en')
-    if string in language_pack:
-        emj_code = language_pack[string]
-        if emj_code in unicode_codes.EMOJI_DATA:
-            return unicode_codes.EMOJI_DATA[emj_code]['E']
+    # Try name lookup
+    emj_code = unicode_codes.get_emoji_by_name(string, 'en')
+    if emj_code and emj_code in unicode_codes.EMOJI_DATA:
+        return unicode_codes.EMOJI_DATA[emj_code]['E']
 
     # Try to find first emoji in string
     version: List[float] = []

--- a/emoji/unicode_codes/__init__.py
+++ b/emoji/unicode_codes/__init__.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+from functools import lru_cache
 from emoji.unicode_codes.data_dict import *
 
 __all__ = [
-    'get_emoji_unicode_dict', 'get_aliases_unicode_dict',
+    'get_emoji_by_name', 'get_emoji_unicode_dict', 'get_aliases_unicode_dict',
     'EMOJI_DATA', 'STATUS', 'LANGUAGES'
 ]
 
@@ -10,6 +11,25 @@ __all__ = [
 _EMOJI_UNICODE: Dict[str, Any] = {lang: None for lang in LANGUAGES}  # Cache for the language dicts
 
 _ALIASES_UNICODE: Dict[str, str] = {}  # Cache for the aliases dict
+
+
+@lru_cache(maxsize=4000)
+def get_emoji_by_name(name: str, lang: str) -> Optional[str]:
+    """Find emoji in a specific language or return None if not found"""
+
+    fully_qualified = STATUS['fully_qualified']
+
+    if lang == 'alias':
+        for emj, data in EMOJI_DATA.items():
+            if name in data.get('alias', []) and data['status'] <= fully_qualified:
+                return emj
+        lang = 'en'
+
+    for emj, data in EMOJI_DATA.items():
+        if data.get(lang) == name and data['status'] <= fully_qualified:
+            return emj
+
+    return None
 
 
 def get_emoji_unicode_dict(lang: str) -> Dict[str, Any]:

--- a/emoji/unicode_codes/__init__.py
+++ b/emoji/unicode_codes/__init__.py
@@ -1,57 +1,33 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 from functools import lru_cache
-from emoji.unicode_codes.data_dict import *
+from emoji.unicode_codes.data_dict import EMOJI_DATA, STATUS, LANGUAGES
 
 __all__ = [
-    'get_emoji_by_name', 'get_emoji_unicode_dict', 'get_aliases_unicode_dict',
+    'get_emoji_by_name',
     'EMOJI_DATA', 'STATUS', 'LANGUAGES'
 ]
 
 
-_EMOJI_UNICODE: Dict[str, Any] = {lang: None for lang in LANGUAGES}  # Cache for the language dicts
-
-_ALIASES_UNICODE: Dict[str, str] = {}  # Cache for the aliases dict
-
-
 @lru_cache(maxsize=4000)
-def get_emoji_by_name(name: str, lang: str) -> Optional[str]:
-    """Find emoji in a specific language or return None if not found"""
+def get_emoji_by_name(name: str, language: str) -> Optional[str]:
+    """
+    Find emoji by short-name in a specific language.
+    Returns None if not found
+
+    :param name: emoji short code e.g. ":banana:"
+    :param language: language-code e.g. 'es', 'de', etc. or 'alias'
+    """
 
     fully_qualified = STATUS['fully_qualified']
 
-    if lang == 'alias':
+    if language == 'alias':
         for emj, data in EMOJI_DATA.items():
             if name in data.get('alias', []) and data['status'] <= fully_qualified:
                 return emj
-        lang = 'en'
+        language = 'en'
 
     for emj, data in EMOJI_DATA.items():
-        if data.get(lang) == name and data['status'] <= fully_qualified:
+        if data.get(language) == name and data['status'] <= fully_qualified:
             return emj
 
     return None
-
-
-def get_emoji_unicode_dict(lang: str) -> Dict[str, Any]:
-    """Generate dict containing all fully-qualified and component emoji name for a language
-    The dict is only generated once per language and then cached in _EMOJI_UNICODE[lang]"""
-
-    if _EMOJI_UNICODE[lang] is None:
-        _EMOJI_UNICODE[lang] = {data[lang]: emj for emj, data in EMOJI_DATA.items()
-                                if lang in data and data['status'] <= STATUS['fully_qualified']}
-
-    return _EMOJI_UNICODE[lang]
-
-
-def get_aliases_unicode_dict() -> Dict[str, str]:
-    """Generate dict containing all fully-qualified and component aliases
-    The dict is only generated once and then cached in _ALIASES_UNICODE"""
-
-    if not _ALIASES_UNICODE:
-        _ALIASES_UNICODE.update(get_emoji_unicode_dict('en'))
-        for emj, data in EMOJI_DATA.items():
-            if 'alias' in data and data['status'] <= STATUS['fully_qualified']:
-                for alias in data['alias']:
-                    _ALIASES_UNICODE[alias] = emj
-
-    return _ALIASES_UNICODE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ repository = "https://github.com/carpedm20/emoji/"
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
+    "pytest>=7.4.4",
     "coverage",
     "coveralls",
 ]
@@ -57,15 +57,23 @@ emoji = ["py.typed"]
 [tool.setuptools.dynamic]
 version = {attr = "emoji.__version__"}
 
+[tool.pytest.ini_options]
+pythonpath = [".", "utils"]
+testpaths = ["tests"]
+addopts = [
+    "--import-mode=importlib",
+]
+
 [tool.pyright]
-pythonVersion = "3.6"
+pythonVersion = "3.7"
 pythonPlatform = "All"
 typeCheckingMode = "strict"
-
+extraPaths = ["utils"]
 exclude = [
   "**/__pycache__",
   ".git",
   ".venv",
   "build",
-  "utils",
+  "utils/gh-pages",
+  "utils/get_codes_from_unicode_emoji_data_files.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ version = {attr = "emoji.__version__"}
 [tool.pytest.ini_options]
 pythonpath = [".", "utils"]
 testpaths = ["tests"]
-addopts = [
-    "--import-mode=importlib",
-]
 
 [tool.pyright]
 pythonVersion = "3.7"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-"""Unittests for emoji."""
-
-
-from . import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+from typing import List
+import random
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser):
+    parser.addoption("--shuffle", dest="shuffle", action='store_true',
+                     default=False, help="Run tests in random order")
+
+
+def pytest_collection_modifyitems(session: pytest.Session,items: List[pytest.Item]):
+    if session.config.getoption("shuffle"):
+        print("")
+        print("Shuffling items for a random test order")
+        random.shuffle(items)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 from typing import List
 import random
 import pytest
+import functools
+
+
+def pytest_sessionstart():
+    # Increase cache size to unlimited size to avoid cache misses during tests
+    import emoji.unicode_codes
+    emoji.unicode_codes.get_emoji_by_name = functools.lru_cache(
+        maxsize=None)(emoji.unicode_codes.get_emoji_by_name.__wrapped__)
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -8,7 +16,7 @@ def pytest_addoption(parser: pytest.Parser):
                      default=False, help="Run tests in random order")
 
 
-def pytest_collection_modifyitems(session: pytest.Session,items: List[pytest.Item]):
+def pytest_collection_modifyitems(session: pytest.Session, items: List[pytest.Item]):
     if session.config.getoption("shuffle"):
         print("")
         print("Shuffling items for a random test order")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,10 +4,8 @@ import random
 import re
 from typing import Any, Callable, Dict, List, Tuple, Union
 from typing_extensions import Literal
-import emoji.unicode_codes
 import pytest
-from typing import Dict, Any, Tuple, Union
-from typing_extensions import Literal
+import emoji.unicode_codes
 from testutils import ascii, normalize, all_language_packs, all_language_and_alias_packs
 
 
@@ -130,13 +128,13 @@ def test_emojize_variant():
         english_pack[':admission_tickets:']) + '\ufe0f'
 
     with pytest.raises(ValueError):
-        emoji.emojize(':admission_tickets:', variant=False)  # pyright: ignore [reportArgumentType]
+        emoji.emojize(':admission_tickets:', variant=False)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError):
-        emoji.emojize(':admission_tickets:', variant=True)  # pyright: ignore [reportArgumentType]
+        emoji.emojize(':admission_tickets:', variant=True)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError):
-        emoji.emojize(':admission_tickets:', variant='wrong')  # pyright: ignore [reportArgumentType]
+        emoji.emojize(':admission_tickets:', variant='wrong')  # type: ignore[arg-type]
 
     assert emoji.emojize(":football:") == ':football:'
     assert emoji.emojize(":football:", variant="text_type") == ':football:'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from typing_extensions import Literal
 import pytest
 import emoji.unicode_codes
-from testutils import ascii, normalize, all_language_packs, all_language_and_alias_packs
+from testutils import ascii, normalize, all_language_packs, all_language_and_alias_packs, get_emoji_unicode_dict
 
 
 def test_emojize_name_only():
@@ -108,7 +108,7 @@ def test_emojize_variant():
     def remove_variant(s: str) -> str:
         return re.sub('[\ufe0e\ufe0f]$', '', s)
 
-    english_pack = emoji.unicode_codes.get_emoji_unicode_dict('en')
+    english_pack = get_emoji_unicode_dict('en')
 
     assert emoji.emojize(
         ':Taurus:', variant=None) == english_pack[':Taurus:']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,30 +6,9 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from typing_extensions import Literal
 import emoji.unicode_codes
 import pytest
-import unicodedata
-
-_NormalizationForm = Literal['NFC', 'NFD', 'NFKC', 'NFKD']
-
-# Build all language packs (i.e. fill the cache):
-emoji.emojize("", language="alias")
-for lang_code in emoji.LANGUAGES:
-    emoji.emojize("", language=lang_code)
-
-
-def ascii(s: str) -> str:
-    # return escaped Code points \U000AB123
-    return s.encode("unicode-escape").decode()
-
-
-def all_language_and_alias_packs():
-    yield ('alias', emoji.unicode_codes.get_aliases_unicode_dict())
-
-    for lang_code in emoji.LANGUAGES:
-        yield (lang_code, emoji.unicode_codes.get_emoji_unicode_dict(lang_code))
-
-
-def normalize(form: _NormalizationForm, s: str) -> str:
-    return unicodedata.normalize(form, s)
+from typing import Dict, Any, Tuple, Union
+from typing_extensions import Literal
+from testutils import ascii, normalize, all_language_packs, all_language_and_alias_packs
 
 
 def test_emojize_name_only():
@@ -116,13 +95,13 @@ def test_emojize_complicated_string():
 
 
 def test_emojize_languages():
-    for lang_code, emoji_pack in emoji.unicode_codes._EMOJI_UNICODE.items():  # pyright: ignore [reportPrivateUsage]
+    for lang_code, emoji_pack in all_language_packs():
         for name, emj in emoji_pack.items():
             assert emoji.emojize(name, language=lang_code) == emj
 
 
 def test_demojize_languages():
-    for lang_code, emoji_pack in emoji.unicode_codes._EMOJI_UNICODE.items():  # pyright: ignore [reportPrivateUsage]
+    for lang_code, emoji_pack in all_language_packs():
         for name, emj in emoji_pack.items():
             assert emoji.demojize(emj, language=lang_code) == name
 
@@ -131,22 +110,24 @@ def test_emojize_variant():
     def remove_variant(s: str) -> str:
         return re.sub('[\ufe0e\ufe0f]$', '', s)
 
-    assert emoji.emojize(
-        ':Taurus:', variant=None) == emoji.unicode_codes._EMOJI_UNICODE['en'][':Taurus:']  # pyright: ignore [reportPrivateUsage]
-    assert emoji.emojize(':Taurus:', variant=None) == emoji.emojize(':Taurus:')
-    assert emoji.emojize(':Taurus:', variant='text_type') == remove_variant(
-        emoji.unicode_codes._EMOJI_UNICODE['en'][':Taurus:']) + '\ufe0e'  # pyright: ignore [reportPrivateUsage]
-    assert emoji.emojize(':Taurus:', variant='emoji_type') == remove_variant(
-        emoji.unicode_codes._EMOJI_UNICODE['en'][':Taurus:']) + '\ufe0f'  # pyright: ignore [reportPrivateUsage]
+    english_pack = emoji.unicode_codes.get_emoji_unicode_dict('en')
 
     assert emoji.emojize(
-        ':admission_tickets:', variant=None) == emoji.unicode_codes._EMOJI_UNICODE['en'][':admission_tickets:']  # pyright: ignore [reportPrivateUsage]
+        ':Taurus:', variant=None) == english_pack[':Taurus:']
+    assert emoji.emojize(':Taurus:', variant=None) == emoji.emojize(':Taurus:')
+    assert emoji.emojize(':Taurus:', variant='text_type') == remove_variant(
+        english_pack[':Taurus:']) + '\ufe0e'
+    assert emoji.emojize(':Taurus:', variant='emoji_type') == remove_variant(
+        english_pack[':Taurus:']) + '\ufe0f'
+
+    assert emoji.emojize(
+        ':admission_tickets:', variant=None) == english_pack[':admission_tickets:']
     assert emoji.emojize(':admission_tickets:', variant=None) == emoji.emojize(
         ':admission_tickets:')
     assert emoji.emojize(':admission_tickets:', variant='text_type') == remove_variant(
-        emoji.unicode_codes._EMOJI_UNICODE['en'][':admission_tickets:']) + '\ufe0e'  # pyright: ignore [reportPrivateUsage]
+        english_pack[':admission_tickets:']) + '\ufe0e'
     assert emoji.emojize(':admission_tickets:', variant='emoji_type') == remove_variant(
-        emoji.unicode_codes._EMOJI_UNICODE['en'][':admission_tickets:']) + '\ufe0f'  # pyright: ignore [reportPrivateUsage]
+        english_pack[':admission_tickets:']) + '\ufe0f'
 
     with pytest.raises(ValueError):
         emoji.emojize(':admission_tickets:', variant=False)  # pyright: ignore [reportArgumentType]

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,6 +1,6 @@
 """Unittests for the big dict of dicts containing all emoji"""
 
-
+from typing import Set, Dict
 import re
 import emoji
 
@@ -8,7 +8,7 @@ import emoji
 def test_all_languages_list():
     """Compare all language keys in EMOJI_DATA with the emoji.LANGUAGES list"""
 
-    langs: set[str] = set()
+    langs: Set[str] = set()
     for item in emoji.EMOJI_DATA.values():
         langs.update(item.keys())
     all_languages = {lang for lang in langs if len(lang) == 2 and lang.lower() == lang}
@@ -27,7 +27,7 @@ def test_emoji_versions():
 
 def check_duplicate_names(lang: str):
     """Check that there are no duplicate names in the fully_qualified except for different variants"""
-    seen = {}
+    seen: Dict[str, int] = {}
     for item in emoji.EMOJI_DATA.values():
         if item["status"] > emoji.STATUS["fully_qualified"]:
             continue

--- a/tests/test_nfkc.py
+++ b/tests/test_nfkc.py
@@ -1,19 +1,8 @@
 """Unittests for canonically equivalent Unicode sequences"""
 
-import sys
-import unicodedata
 import emoji
-from typing_extensions import Literal
 
-
-_NormalizationForm = Literal['NFC', 'NFD', 'NFKC', 'NFKD']
-
-def is_normalized(form: _NormalizationForm, s: str) -> bool:
-    if sys.version_info >= (3, 8):
-        return unicodedata.is_normalized(form, s)
-    else:
-        return unicodedata.normalize(form, s) == s
-
+from testutils import is_normalized
 
 def test_database_normalized():
     # Test if all names in EMOJI_DATA are in NFKC form

--- a/tests/test_nfkc.py
+++ b/tests/test_nfkc.py
@@ -1,7 +1,6 @@
 """Unittests for canonically equivalent Unicode sequences"""
 
 import emoji
-
 from testutils import is_normalized
 
 def test_database_normalized():

--- a/tests/test_unicode_codes.py
+++ b/tests/test_unicode_codes.py
@@ -1,5 +1,6 @@
 """Unittests for emoji.unicode_codes."""
 
+from typing import Set
 import emoji.unicode_codes
 from testutils import get_language_packs
 
@@ -25,7 +26,7 @@ def test_compare_normal_and_aliases():
 def test_no_alias_duplicates():
     # There should not be two emoji with the same alias
     # (aliases still can be the same as another 'en'-name)
-    all_aliases: set[str] = set()
+    all_aliases: Set[str] = set()
     for data in emoji.EMOJI_DATA.values():
         if data['status'] <= emoji.STATUS['fully_qualified'] and 'alias' in data:
             for alias in data['alias']:

--- a/tests/test_unicode_codes.py
+++ b/tests/test_unicode_codes.py
@@ -1,31 +1,25 @@
 """Unittests for emoji.unicode_codes."""
 
 import emoji.unicode_codes
-
-# Build all language packs (i.e. fill the cache):
-emoji.emojize("", language="alias")
-for lang_code in emoji.LANGUAGES:
-    emoji.emojize("", language=lang_code)
+from testutils import get_language_packs
 
 
 def test_emoji_english_names():
-
-    for language, group in (
-            ('en', emoji.unicode_codes._EMOJI_UNICODE['en']),  # pyright: ignore [reportPrivateUsage]
-            ('alias', emoji.unicode_codes._ALIASES_UNICODE)  # pyright: ignore [reportPrivateUsage]
-    ):
+    for language, group in get_language_packs('en', 'alias'):
         for name, ucode in group.items():
             assert name.startswith(':') and name.endswith(':') and len(name) >= 3
             emj = emoji.emojize(name, language=language)
-            assert emj == ucode, '%s != %s' % (emoji.emojize(name), ucode)
+            assert emj == ucode, '"%s" == "%s"' % (emj, ucode)
 
 
 def test_compare_normal_and_aliases():
     # There should always be more aliases than normal codes
     # since the aliases contain the normal codes
 
-    assert len(emoji.unicode_codes._EMOJI_UNICODE['en']) < len(  # pyright: ignore [reportPrivateUsage]
-        emoji.unicode_codes._ALIASES_UNICODE)  # pyright: ignore [reportPrivateUsage]
+    english_pack = emoji.unicode_codes.get_emoji_unicode_dict('en')
+    alias_pack = emoji.unicode_codes.get_aliases_unicode_dict()
+
+    assert len(english_pack) < len(alias_pack)
 
 
 def test_no_alias_duplicates():

--- a/tests/test_unicode_codes.py
+++ b/tests/test_unicode_codes.py
@@ -2,7 +2,7 @@
 
 from typing import Set
 import emoji.unicode_codes
-from testutils import get_language_packs
+from testutils import get_language_packs, get_aliases_unicode_dict, get_emoji_unicode_dict
 
 
 def test_emoji_english_names():
@@ -17,8 +17,8 @@ def test_compare_normal_and_aliases():
     # There should always be more aliases than normal codes
     # since the aliases contain the normal codes
 
-    english_pack = emoji.unicode_codes.get_emoji_unicode_dict('en')
-    alias_pack = emoji.unicode_codes.get_aliases_unicode_dict()
+    english_pack = get_emoji_unicode_dict('en')
+    alias_pack = get_aliases_unicode_dict()
 
     assert len(english_pack) < len(alias_pack)
 
@@ -32,3 +32,16 @@ def test_no_alias_duplicates():
             for alias in data['alias']:
                 assert alias not in all_aliases
                 all_aliases.add(alias)
+
+
+def test_get_emoji_by_alias():
+    # Compare get_emoji_by_name() to get_aliases_unicode_dict()
+    for alias, emj in get_aliases_unicode_dict().items():
+        assert emoji.unicode_codes.get_emoji_by_name(alias, 'alias') == emj
+
+
+def test_get_emoji_by_name():
+    # Compare get_emoji_by_name() to get_emoji_unicode_dict()
+    for lang in emoji.LANGUAGES:
+        for name, emj in get_emoji_unicode_dict(lang).items():
+            assert emoji.unicode_codes.get_emoji_by_name(name, lang) == emj

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -3,12 +3,12 @@
 from typing import Any, Dict, List
 import emoji.unicode_codes
 import pytest
-
+from testutils import all_language_packs
 
 def test_emoji_versions_complete_emojize():
     # Check that every emoji has a valid version
     replacement = "<3"
-    for lang_code, emoji_pack in emoji.unicode_codes._EMOJI_UNICODE.items():  # pyright: ignore [reportPrivateUsage]
+    for lang_code, emoji_pack in all_language_packs():
         for name in emoji_pack.keys():
             version: List[float] = []
 
@@ -28,7 +28,7 @@ def test_emoji_versions_complete_emojize():
 
 def test_emoji_versions_complete_demojize():
     # Check that every emoji has a valid version
-    for lang_code, emoji_pack in emoji.unicode_codes._EMOJI_UNICODE.items():  # pyright: ignore [reportPrivateUsage]
+    for lang_code, emoji_pack in all_language_packs():
         for name in emoji_pack.keys():
             version: List[float] = []
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,8 +1,8 @@
 """Unittests for versions in EMOJI_DATA"""
 
 from typing import Any, Dict, List
-import emoji.unicode_codes
 import pytest
+import emoji.unicode_codes
 from testutils import all_language_packs
 
 def test_emoji_versions_complete_emojize():

--- a/utils/get_codes_from_unicode_emoji_data_files.py
+++ b/utils/get_codes_from_unicode_emoji_data_files.py
@@ -396,8 +396,14 @@ def add_unicode_annotations(data, lang, url):
             emoji_name = adapt_emoji_name(text, lang, emj)
 
             if emj in data and data[emj] != emoji_name:
+                if "\U0000200D\U000027A1" in emj:
+                    # Skip right-facing emoji (i.e. 🧑🏻‍🦽 vs 🧑🏻‍🦽‍➡️) for now  because they are not correctly translated yet
+                    print(f"# {lang}: {emj} SKIPPED CHANGE FROM {data[emj]} TO {emoji_name} \t\t(Source: {text})")
+                    continue
+
                 print(
-                    f"# {lang}: CHANGED {data[emj]} TO {emoji_name} \t\t(Original: {text})")
+                    f"# {lang}: {emj} CHANGED {data[emj]} TO {emoji_name} \t\t(Source: {text})")
+
             data[emj] = emoji_name
 
 
@@ -505,7 +511,7 @@ if __name__ == "__main__":
     emoji_sequences_source = get_emoji_variation_sequence_from_url('15.1.0')
     emojis = extract_emojis(emoji_source, emoji_sequences_source)
     # Find latest release tag at https://cldr.unicode.org/index/downloads
-    github_tag = 'release-44-1'
+    github_tag = 'release-45'
 
     languages = {
         # Update names in other languages:

--- a/utils/testutils.py
+++ b/utils/testutils.py
@@ -1,0 +1,41 @@
+from typing import Generator, Dict, Any, Tuple, Iterable
+import sys
+import unicodedata
+import emoji.unicode_codes
+from typing_extensions import Literal
+
+_NormalizationForm = Literal['NFC', 'NFD', 'NFKC', 'NFKD']
+
+
+def ascii(s: str) -> str:
+    """return escaped Code points for non-ascii chars like \U000AB123"""
+    return s.encode("unicode-escape").decode()
+
+
+def normalize(form: _NormalizationForm, s: str) -> str:
+    return unicodedata.normalize(form, s)
+
+
+def is_normalized(form: _NormalizationForm, s: str) -> bool:
+    if sys.version_info >= (3, 8):
+        return unicodedata.is_normalized(form, s)
+    else:
+        return normalize(form, s) == s
+
+
+def all_language_packs() -> Generator[Tuple[str, Dict[str, Any]], None, None]:
+    for lang_code in emoji.LANGUAGES:
+        yield (lang_code, emoji.unicode_codes.get_emoji_unicode_dict(lang_code))
+
+
+def all_language_and_alias_packs(
+) -> Generator[Tuple[str, Dict[str, Any]], None, None]:
+    yield ('alias', emoji.unicode_codes.get_aliases_unicode_dict())
+    yield from all_language_packs()
+
+
+def get_language_packs(
+        *langs: Iterable[str]) -> Generator[Tuple[str, Dict[str, Any]], None, None]:
+    for lang_code, lang_pack in all_language_and_alias_packs():
+        if lang_code in langs:
+            yield (lang_code, lang_pack)


### PR DESCRIPTION
Changes:
* Fix some of the `type: ignore` in core.py and tokenizer.py
* Move helper functions from tests into separate file `utils/testutils.py`
* Replace usage of private `_EMOJI_UNICODE` in tests
* Add an option to run tests in random order with `pytest --shuffle`
* Run tests in normal and random order in CI
* Upgrade CI to ubuntu-22.04
* Add `pypy-3.10` to CI tests, we have [listed pypy as supported](https://github.com/carpedm20/emoji/blob/fd4230cab1243781f176e9d8405a16208722ce4f/pyproject.toml#L28), so we should test it
* Use `@functools.lru_cache` to reverse `EMOJI_DATA` with new function `get_emoji_by_name()` #292
* Move `get_emoji_unicode_dict()`, `get_aliases_unicode_dict()`, `_EMOJI_UNICODE` and `_ALIASES_UNICODE` to testutils. They are not longer needed with the new `get_emoji_by_name()` function, but they are still used in the tests
* Update Unicode translation to `release-45`, but there were no changes to any emoji translations