### PR TITLE
Prepare for v2.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 emoji
 =====
 
+v2.12.0 (2024-05-19)
+-----
+* Move type annotations inline
+* Use `functools.lru_cache` for looking up emoji by name with `get_emoji_by_name()`
+* Move internal functions `get_emoji_unicode_dict()`, `get_aliases_unicode_dict()`, `_EMOJI_UNICODE` and `_ALIASES_UNICODE` to `testutils`
+* Add type hints to tests
+* Remove obsolete dev dependency `coveralls`
+
 v2.11.1 (2024-04-21)
 -----
 * Add missing stubs for purely_emoji
@@ -9,7 +17,7 @@ v2.11.0 (2024-03-26)
 -----
 * Update to Unicode v15.1
 
-v2.10.1 (TBD)
+v2.10.1 (2024-01-31)
 -----
 * Fix slow import when debugging in Python 3.12 #280
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include LICENSE.txt
 include MANIFEST.in
 include README.rst
 include CHANGES.md
+include utils/testutils.py
 recursive-include tests *.py

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     'EMOJI_DATA', 'STATUS', 'LANGUAGES',
 ]
 
-__version__ = '2.11.1'
+__version__ = '2.12.0'
 __author__ = 'Taehoon Kim, Kevin Wurster'
 __email__ = 'carpedm20@gmail.com'
 # and wursterk@gmail.com, tahir.jalilov@gmail.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ repository = "https://github.com/carpedm20/emoji/"
 dev = [
     "pytest>=7.4.4",
     "coverage",
-    "coveralls",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This is ready for release now.

Changes:
* Remove dev-dependency `coveralls`, we don't use that
* Add `utils/testutils.py` to MANIFEST.in to include it in source tarballs