### PR TITLE
Release 2.12.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 emoji
 =====
 
+v2.12.1 (2024-05-20)
+-----
+* `typing-extensions` requires at least version `4.7.0` #297
+
 v2.12.0 (2024-05-19)
 -----
 * Move type annotations inline

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     'EMOJI_DATA', 'STATUS', 'LANGUAGES',
 ]
 
-__version__ = '2.12.0'
+__version__ = '2.12.1'
 __author__ = 'Taehoon Kim, Kevin Wurster'
 __email__ = 'carpedm20@gmail.com'
 # and wursterk@gmail.com, tahir.jalilov@gmail.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Typing :: Typed"
 ]
 dependencies = [
-    "typing_extensions",
+    "typing_extensions >= 4.7.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Specify `typing-extensions >= 4.7.0` in pyproject.toml

Fix #297