### PR TITLE
Fix UnicodeDecodeError v2.13.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 emoji
 =====
 
+v2.13.1 (2024-09-21)
+-----
+* Read JSON files in binary mode to avoid UnicodeDecodeError #305
+
 v2.13.0 (2024-09-19)
 -----
 * Use JSON files to store the database of emoji

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include README.rst
 include CHANGES.md
 include utils/testutils.py
 recursive-include tests *.py
+include emoji/unicode_codes/emoji.json
+recursive-include emoji/unicode_codes emoji_*.json

--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
     'LANGUAGES',
 ]
 
-__version__ = '2.13.0'
+__version__ = '2.13.1'
 __author__ = 'Taehoon Kim, Kevin Wurster'
 __email__ = 'carpedm20@gmail.com'
 # and wursterk@gmail.com, tahir.jalilov@gmail.com

--- a/emoji/unicode_codes/__init__.py
+++ b/emoji/unicode_codes/__init__.py
@@ -78,7 +78,9 @@ EMOJI_DATA: Dict[str, Dict[str, Any]]
 def _load_default_from_json():
     global EMOJI_DATA
     global _loaded_keys
-    with open(Path(__file__).with_name('emoji.json')) as f:
+
+    file = Path(__file__).with_name('emoji.json')
+    with open(file, 'rb') as f:
         EMOJI_DATA = dict(json.load(f, object_pairs_hook=EmojiDataDict))  # type: ignore
     _loaded_keys = list(_DEFAULT_KEYS)
 
@@ -93,7 +95,7 @@ def load_from_json(key: str):
         raise NotImplementedError('Language not supported', key)
 
     file = Path(__file__).with_name(f'emoji_{key}.json')
-    with open(file) as f:
+    with open(file, 'rb') as f:
         for emj, value in json.load(f).items():
             EMOJI_DATA[emj][key] = value  # type: ignore
 


### PR DESCRIPTION
read JSON files in binary mode with `open(..., 'rb')`

Fixes #305