### PR TITLE
Remove `typing_extensions` dependency on Python 3.9 and higher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ emoji
 v2.13.1 (2024-09-21)
 -----
 * Read JSON files in binary mode to avoid UnicodeDecodeError #305
+* `typing_extensions` dependency not required on Python 3.9 and higher #303
 
 v2.13.0 (2024-09-19)
 -----

--- a/emoji/core.py
+++ b/emoji/core.py
@@ -12,7 +12,7 @@ import sys
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 if sys.version_info < (3, 9):
-    from typing_extensions import Literal, Match, TypedDict
+    from typing_extensions import Literal, Match, TypedDict  # type: ignore
 else:
     from typing import Literal, Match, TypedDict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["typing_extensions >= 4.7.0"]
+dependencies = ["typing_extensions >= 4.7.0; python_version < '3.9'"]
 dynamic = ["version"]
 
 [project.urls]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ import sys
 
 from typing import Any, Callable, Dict, List, Tuple, Union
 if sys.version_info < (3, 9):
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 else:
     from typing import Literal
 import pytest

--- a/utils/testutils.py
+++ b/utils/testutils.py
@@ -4,7 +4,7 @@ import unicodedata
 
 import pytest
 if sys.version_info < (3, 9):
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 else:
     from typing import Literal
 


### PR DESCRIPTION
@TahirJalilov You can merge this and afterwards publish release v2.13.1 
