### PR TITLE
Fix incorrect order of robot for languages `alias` and `en`

### DIFF
--- a/emoji/unicode_codes/emoji.json
+++ b/emoji/unicode_codes/emoji.json
@@ -19668,10 +19668,10 @@
   "alias": [":sweet_potato:"]
 },
 "🤖": {
-  "en": ":robot:",
+  "en": ":robot_face:",
   "status": 2,
   "E": 1,
-  "alias": [":robot_face:"]
+  "alias": [":robot:"]
 },
 "🪨": {
   "en": ":rock:",


### PR DESCRIPTION
Refering to https://github.com/carpedm20/emoji/pull/102/files#diff-48bad5f533ed8ca39c7260b339db68d37fa13b547ed4f14ccfaafd5cb99b97d8

I noticed that in the current version, the alias name is ":robot_face:" and not ":robot:" as was addressed in #102  

This PR sets 🤖 to ":robot_face:" for en and ":robot:" for alias in the json file.