### PR TITLE
Fix purely_emoji() for empty strings

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -405,6 +405,8 @@ def purely_emoji(string: str) -> bool:
     This might not imply that `is_emoji` for all the characters, for example,
     if the string contains variation selectors.
     """
+    if not string:
+        return False
     return all(isinstance(m.value, EmojiMatch) for m in analyze(string, non_emoji=True))
 
 


### PR DESCRIPTION
Fixes #300 <!-- Needed for GitHub to link the issue to the PR -->

## Fix purely_emoji() for empty strings
The `purely_emoji()` function incorrectly returned `True` for empty strings. This change makes it return `False` instead, which is more intuitive behavior.

The fix adds an explicit check for empty strings before analyzing the content. This matches the expected behavior where an empty string shouldn&#39;t be considered as containing emojis.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1YnVzZXJjb250ZW50LmNvbS9oYXJyeS1wYXRjaGVyLzU2NDNmNjg5ZmQxMGVlOGJmZWZkZTBjNzNiMjU0MDU2L3Jhdy8yYmE0NGNmZDQ1MDgwYTY4YjRmNmZlOTE5M2U0ZWNhZDQwZmMyYWM4L3N3ZWJlbmNoX2NhcnBlZG0yMF9fZW1vamktMzAwLmpzb24) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=&rb85bea8de07843f9835f9d001f689f4c=&r034de175aef248b29aaf36f2a5e92912=&r9e0cc5d7ff8b484e81eb97531d4cefd7=) 📬.