### PR TITLE
Return False from purely_emoji for empty string

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -399,6 +399,8 @@ def purely_emoji(string: str) -> bool:
     This might not imply that `is_emoji` for all the characters, for example,
     if the string contains variation selectors.
     """
+    if not string:
+        return False
     return all(isinstance(m.value, EmojiMatch) for m in analyze(string, non_emoji=True))
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -707,6 +707,7 @@ purely_emoji_testdata = [
     ('abc\U0001f600', False),
     ('\U0001f600c', False),
     ('\u270a\U0001f3fe', True),
+    ('', False),
 ]
 
 


### PR DESCRIPTION
Fixes #300

Currently purely_emoji('') returns True because ll() on an empty iterable is True in Python. An empty string does not contain any emojis, so it should return False.

Added an early return for empty strings and a corresponding test case.