### PR TITLE
Load JSON data with orjson

### DIFF
--- a/emoji/unicode_codes/__init__.py
+++ b/emoji/unicode_codes/__init__.py
@@ -1,12 +1,17 @@
-import sys
 import importlib.resources
-import json
+import sys
 from functools import lru_cache
+from typing import IO, Any, Dict, Optional, Set
 from warnings import warn
 
-from typing import IO, Any, Dict, Optional, Set
+import orjson
 
-from emoji.unicode_codes.data_dict import STATUS, LANGUAGES
+
+def _loads(data: bytes) -> Any:
+    return orjson.loads(data)
+
+
+from emoji.unicode_codes.data_dict import LANGUAGES, STATUS
 
 __all__ = [
     'get_emoji_by_name',
@@ -78,7 +83,9 @@ EMOJI_DATA: Dict[str, Dict[str, Any]]
 
 def _open_file(name: str) -> IO[bytes]:
     if sys.version_info >= (3, 9):
-        return importlib.resources.files('emoji.unicode_codes').joinpath(name).open('rb')
+        return (
+            importlib.resources.files('emoji.unicode_codes').joinpath(name).open('rb')
+        )
     else:
         return importlib.resources.open_binary('emoji.unicode_codes', name)
 
@@ -88,7 +95,8 @@ def _load_default_from_json():
     global _loaded_keys
 
     with _open_file('emoji.json') as f:
-        EMOJI_DATA = dict(json.load(f, object_pairs_hook=EmojiDataDict))  # type: ignore
+        raw = _loads(f.read())
+    EMOJI_DATA = {k: EmojiDataDict(v) for k, v in raw.items()}  # type: ignore
     _loaded_keys = set(_DEFAULT_KEYS)
 
 
@@ -102,7 +110,7 @@ def load_from_json(key: str):
         raise NotImplementedError('Language not supported', key)
 
     with _open_file(f'emoji_{key}.json') as f:
-        for emj, value in json.load(f).items():
+        for emj, value in _loads(f.read()).items():
             EMOJI_DATA[emj][key] = value  # type: ignore
 
     _loaded_keys.add(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
+dependencies = ["orjson"]
 
 [project.urls]
 homepage = "https://github.com/carpedm20/emoji/"

--- a/utils/generate_emoji.py
+++ b/utils/generate_emoji.py
@@ -6,17 +6,16 @@ and the aliases from various sources.
 and combine it with the existing emoji data from the emoji package.
 """
 
-import sys
+import logging
 import os
+import re
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
-import re
-import logging
-import json
 
-import requests
 import bs4
-
+import orjson
+import requests
 from generateutils import get_text_from_url, to_ascii
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -442,6 +441,6 @@ if __name__ == '__main__':
 
     logging.info('\n\n  Checking json file. Any errors should appear below:\n')
     with open(out_file, 'rt', encoding='utf-8') as fp:
-        json.load(fp)
+        orjson.loads(fp.read())
     with open(out_file, 'rb') as fp:
-        json.load(fp)
+        orjson.loads(fp.read())

--- a/utils/generate_emoji_translations.py
+++ b/utils/generate_emoji_translations.py
@@ -4,19 +4,18 @@ The translation is based on the Unicode CLDR annotations and the emojiterra.com 
 The output files are emoji_{xy}.json where {xy} is the letter language code
 """
 
-import sys
+import io
+import logging
 import os
+import re
+import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, Optional, Set
-import re
-import io
-import xml.etree.ElementTree as ET
-import logging
-import json
 
 import bs4
-
-from generateutils import get_text_from_url, adapt_emoji_name, to_ascii
+import orjson
+from generateutils import adapt_emoji_name, get_text_from_url, to_ascii
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
@@ -272,6 +271,6 @@ if __name__ == '__main__':
         logging.info(f'   *  {out_file}')
 
         with open(out_file, 'rt', encoding='utf-8') as fp:
-            json.load(fp)
+            orjson.loads(fp.read())
         with open(out_file, 'rb') as fp:
-            json.load(fp)
+            orjson.loads(fp.read())


### PR DESCRIPTION
Profiling a client project’s import time with `python -X importtime`, I found that `emoji`  takes ~5ms to import (excluding its depedencies). The majority of that time was spent in `emoji.unicode_codes` loading the JSON data.

This PR switches to `orjson` for loading the JSON data, which is significantly faster than the built-in `json` module.

This change cuts the import time to 4ms, a 20% saving. It’s less than I hoped for, but as a fairly straightforward optimization I think it’s worth it.