### PR TITLE
fix: validate variant argument upfront in emojize()

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -164,6 +164,11 @@ def emojize(
 
     """
 
+    if variant not in (None, 'text_type', 'emoji_type'):
+        raise ValueError(
+            "Parameter 'variant' must be either None, 'text_type' or 'emoji_type'"
+        )
+
     unicode_codes.load_from_json(language)
 
     pattern = re.compile(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -168,6 +168,15 @@ def test_emojize_variant():
         with pytest.raises(ValueError):
             emoji.emojize(':admission_tickets:', variant='wrong')  # type: ignore[arg-type]
 
+        # ValueError must be raised unconditionally regardless of whether the
+        # input string contains no emoji at all, or only emoji without a variant
+        # key. Previously these silently accepted the invalid argument.
+        with pytest.raises(ValueError):
+            emoji.emojize('hello world', variant='bogus')  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError):
+            emoji.emojize(':thumbs_up:', variant='bogus')  # type: ignore[arg-type]
+
     assert emoji.emojize(':football:') == ':football:'
     assert emoji.emojize(':football:', variant='text_type') == ':football:'
     assert emoji.emojize(':football:', language='alias') == '\U0001f3c8'


### PR DESCRIPTION
## Summary

The docstring for `emojize()` states that it raises `ValueError` when
`variant` is not `None`, `'text_type'`, or `'emoji_type'`. The check was
placed inside the per-match substitution callback, and only ran for emoji
that carry a `'variant'` key in `EMOJI_DATA`. This caused the same
invalid argument to behave inconsistently depending on what the input
string contained:

```python
import emoji

emoji.emojize("hello world", variant="bogus")   # silent (no emoji in string)
emoji.emojize(":thumbs_up:", variant="bogus")   # silent (thumbs_up has no variant entry)
emoji.emojize(":red_heart:", variant="bogus")   # ValueError
```

Fixes #330

## Changes

- Added an upfront check for `variant` at the start of `emojize()`,
  before the regex substitution loop, so that an invalid value always
  raises `ValueError` regardless of the input string.
- Added two regression tests:
  - `variant='bogus'` on a string with no emoji raises `ValueError`
  - `variant='bogus'` on an emoji without a variant entry raises `ValueError`

## Testing

```
pytest tests/test_core.py::test_emojize_variant -v
# 1 passed
pytest tests/test_core.py -q
# 33 passed
```