### PR TITLE
fix: is_emoji() returns True for fully-qualified emoji with VS16

### DIFF
--- a/emoji/core.py
+++ b/emoji/core.py
@@ -390,7 +390,14 @@ def is_emoji(string: str) -> bool:
     Returns True if the string is a single emoji, and it is "recommended for
     general interchange" by Unicode.org.
     """
-    return string in unicode_codes.EMOJI_DATA
+    if string in unicode_codes.EMOJI_DATA:
+        return True
+    # Check if the string is a fully-qualified form with variation selector
+    if string.endswith('\uFE0F'):
+        base = string[:-1]
+        if base in unicode_codes.EMOJI_DATA:
+            return unicode_codes.EMOJI_DATA[base].get('variant') is not None
+    return False
 
 
 def purely_emoji(string: str) -> bool:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -474,6 +474,10 @@ def test_is_emoji():
     assert emoji.is_emoji('🇫🇷')
     assert not emoji.is_emoji('🇫🇷🇫🇷')
     assert not emoji.is_emoji('\ufe0f')  # variation selector
+    # Fully-qualified emoji with variation selector (issue #325)
+    assert emoji.is_emoji('\u2615\ufe0f')  # ☕️
+    assert emoji.is_emoji('\u2615')  # ☕ (without VS16)
+    assert not emoji.is_emoji('\u2615\ufe0f\ufe0f')  # double VS16 is invalid
 
 
 def test_long_emoji():


### PR DESCRIPTION
Fixes #325

## Problem

is_emoji("☕️") returns False because the fully-qualified form (☕ + U+FE0F variation selector) is not stored in EMOJI_DATA directly — only the base character ☕ (U+2615) is.

## Root Cause

is_emoji() does a simple dict lookup in EMOJI_DATA. Emoji that support variation selectors are stored only as the base codepoint, but users commonly copy-paste the fully-qualified form from platforms which append VS16.

## Fix

When the string is not directly in EMOJI_DATA and ends with U+FE0F, strip it and check if the base character exists with a variant entry. This is minimal and does not affect performance for the common case (direct lookup still comes first).

## Validation

- Full test suite passes (102 tests)
- Regression test added in test_core.py::test_is_emoji